### PR TITLE
[FIXED JENKINS-19993] - Ownership does not saves default security on reconfiguration

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction.java
@@ -60,10 +60,12 @@ public class JobOwnerJobAction extends ItemOwnershipAction<Job<?,?>> {
         return getDescribedItem();
     }
     
+    @Override
     public Permission getOwnerPermission() {
         return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
     }
     
+    @Override
     public Permission getProjectSpecificPermission() {
         return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
     }
@@ -75,16 +77,25 @@ public class JobOwnerJobAction extends ItemOwnershipAction<Job<?,?>> {
     
     public ItemSpecificSecurity getItemSpecificSecurity() {
         JobOwnerJobProperty prop = JobOwnerHelper.getOwnerProperty(getDescribedItem());
-        if (prop != null && prop.getItemSpecificSecurity() != null) {
+        if (prop != null && prop.hasItemSpecificSecurity()) {
              return prop.getItemSpecificSecurity();
-        }
-        
-        return getGlobalIemSpecificSecurity();
+        }        
+        return getGlobalItemSpecificSecurity();
     }
     
-    private static ItemSpecificSecurity getGlobalIemSpecificSecurity() {
+    private static ItemSpecificSecurity getGlobalItemSpecificSecurity() {
         ItemSpecificSecurity defaultJobsSecurity = OwnershipPlugin.Instance().getDefaultJobsSecurity();
         return defaultJobsSecurity;
+    }
+    
+    /**
+     * Checks if the described item has a job-specific security defined.
+     * @return true if the item has a job-specific security
+     * @since 0.3.1
+     */
+    public boolean hasItemSpecificSecurity() {
+        JobOwnerJobProperty prop = JobOwnerHelper.getOwnerProperty(getDescribedItem());
+        return prop != null && prop.hasItemSpecificSecurity();
     }
     
     public ItemSpecificSecurity.ItemSpecificDescriptor getItemSpecificDescriptor() {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobProperty.java
@@ -74,10 +74,27 @@ public class JobOwnerJobProperty extends JobProperty<Job<?, ?>>
         return (ownership!=null) ? ownership : OwnershipDescription.DISABLED_DESCR;
     }
 
+    /**
+     * Gets current configuration of item-specific security.
+     * The function returns a default configuration if security is not
+     * configured. Use {@link #hasItemSpecificSecurity() hasItemSpecificSecurity} 
+     * to check an origin of permissions.
+     * @return ItemSpecific security or null if it is not configured
+     * @since 0.3
+     */
     public ItemSpecificSecurity getItemSpecificSecurity() {
         return itemSpecificSecurity != null 
                 ? itemSpecificSecurity 
                 : OwnershipPlugin.Instance().getDefaultJobsSecurity();
+    }
+    
+    /**
+     * Checks if job-specific security is configured.
+     * @return true if job-specific security is configured
+     * @since 0.3.1
+     */
+    public boolean hasItemSpecificSecurity() {
+        return itemSpecificSecurity != null;
     }
     
     public String getDisplayName(User usr) {
@@ -104,7 +121,7 @@ public class JobOwnerJobProperty extends JobProperty<Job<?, ?>>
 
     @Override
     public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
-        return new JobOwnerJobProperty(getOwnership(), getItemSpecificSecurity());
+        return new JobOwnerJobProperty(ownership, itemSpecificSecurity);
     }
     
     @Extension

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipActionFactory.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipActionFactory.java
@@ -41,5 +41,5 @@ public class OwnershipActionFactory extends TransientProjectActionFactory {
     public Collection<? extends Action> createFor(AbstractProject target) {
         return singleton(new JobOwnerJobAction(target));
     }
-    
+   
 }

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/configure-project-specifics.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/configure-project-specifics.jelly
@@ -36,8 +36,7 @@
                 <!--Item-specific security-->
                 <f:optionalBlock name="itemSpecificSecurity" 
                      title="${%Use item-specific security}"
-                     checked="${it.itemSpecificSecurity != null}">
-                    
+                     checked="${it.hasItemSpecificSecurity()}">                   
                     <j:set var="descriptor" value="${it.itemSpecificDescriptor}"/>
                     <j:set var="instance" value="${it.itemSpecificSecurity}"/>
                     <st:include from="${descriptor}" page="${descriptor.configPage}"/> 


### PR DESCRIPTION
Fix adds checks for existence of job-specific security.

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
