### PR TITLE
Avoid confusing node property shown on config screen

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/OwnerNodeProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/OwnerNodeProperty.java
@@ -139,7 +139,7 @@ public class OwnerNodeProperty extends NodeProperty<Node>
         
         @Override
         public String getDisplayName() {
-                return Messages.NodeOwnership_Config_SectionTitle()+". (just a stub, use \"Manage ownership\" page to configure)";
+                return null;
         }
 
         @Override


### PR DESCRIPTION
Hide the property instead.

Passed manual tests and [ATH](https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/test/java/plugins/OwnershipPluginTest.java).