### PR TITLE
[JENKINS-26283] - Add support of "Contact owners" functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <version>1.6</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.4</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
@@ -62,15 +62,6 @@ public interface IOwnershipHelper<TObjectType>  {
     public @CheckForNull String getItemURL(@Nonnull TObjectType item);
     
     /**
-     * Generate a mailto URL, which allows to contact owners.
-     * This URL should define default subject and body.
-     * @param item 
-     * @return MailTo URL or null if it is not available
-     * @since 0.6
-     */
-    public @CheckForNull String getContactOwnersMailToURL(@Nonnull TObjectType item);
-    
-    /**
      * Get ID of the item's owner.
      * @param item Item to be describes
      * @return userId or null

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
@@ -43,6 +43,33 @@ import javax.annotation.Nonnull;
  * @see NodeOwnerHelper
  */
 public interface IOwnershipHelper<TObjectType>  {
+    
+    /**
+     * Gets a short classifier.
+     * Usage example: e-mail headers
+     * @param item
+     * @return Short description of the object
+     * @since 0.6
+     */
+    public @Nonnull String getItemSummary(@Nonnull TObjectType item);
+    
+    /**
+     * Gets a relative URL to the item.
+     * @param item
+     * @return Relative URL or null if it is not available
+     * @since 0.6
+     */
+    public @CheckForNull String getItemURL(@Nonnull TObjectType item);
+    
+    /**
+     * Generate a mailto URL, which allows to contact owners.
+     * This URL should define default subject and body.
+     * @param item 
+     * @return MailTo URL or null if it is not available
+     * @since 0.6
+     */
+    public @CheckForNull String getContactOwnersMailToURL(@Nonnull TObjectType item);
+    
     /**
      * Get ID of the item's owner.
      * @param item Item to be describes

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
@@ -26,6 +26,7 @@ package com.synopsys.arc.jenkins.plugins.ownership;
 import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.nodes.ComputerOwnerHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.nodes.NodeOwnerHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import hudson.model.User;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
@@ -41,6 +42,7 @@ import javax.annotation.Nonnull;
  * @see JobOwnerHelper
  * @see ComputerOwnerHelper
  * @see NodeOwnerHelper
+ * @see AbstractOwnershipHelper
  */
 public interface IOwnershipHelper<TObjectType>  {
     
@@ -106,7 +108,8 @@ public interface IOwnershipHelper<TObjectType>  {
     /**
      * Get list of users, who can be item's owner.
      * @param item Item to be described
-     * @return List of users, who can be item's owner (always non-null)
+     * @return List of users, who can be item's owner (always non-null).
+     *    By default, the method returns an empty list in {@link AbstractOwnershipHelper}.
      * @since 0.0.3
      */
     @Nonnull

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
@@ -47,13 +47,20 @@ import javax.annotation.Nonnull;
 public interface IOwnershipHelper<TObjectType>  {
     
     /**
+     * Gets a type of the item to be displayed.
+     * @param item 
+     * @return Display name of the item type
+     */
+    public @Nonnull String getItemTypeName(@Nonnull TObjectType item);
+    
+    /**
      * Gets a short classifier.
      * Usage example: e-mail headers
      * @param item
      * @return Short description of the object
      * @since 0.6
      */
-    public @Nonnull String getItemSummary(@Nonnull TObjectType item);
+    public @Nonnull String getItemDisplayName(@Nonnull TObjectType item);
     
     /**
      * Gets a relative URL to the item.

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/ItemOwnershipAction.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/ItemOwnershipAction.java
@@ -65,5 +65,9 @@ public abstract class ItemOwnershipAction<TObjectType extends Actionable>
      */
     @Nonnull
     public abstract Permission getProjectSpecificPermission();
-    
+
+    @Override
+    public OwnershipDescription getOwnership() {
+        return helper().getOwnershipDescription(describedItem);
+    } 
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
@@ -25,9 +25,11 @@
 package com.synopsys.arc.jenkins.plugins.ownership;
 
 import com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy;
+import com.synopsys.arc.jenkins.plugins.ownership.util.mail.MailOptions;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -40,16 +42,28 @@ public class OwnershipPluginConfiguration
         implements Describable<OwnershipPluginConfiguration> {
 
     private final ItemOwnershipPolicy itemOwnershipPolicy;
+    private final @CheckForNull MailOptions mailOptions;
 
     @DataBoundConstructor
-    public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy) {
+    public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy, 
+            @Nonnull MailOptions mailOptions) {
         this.itemOwnershipPolicy = itemOwnershipPolicy;
+        this.mailOptions = mailOptions;
+    }
+    
+    @Deprecated
+    public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy) {
+        this (itemOwnershipPolicy, MailOptions.DEFAULT);
     }
 
     public @Nonnull ItemOwnershipPolicy getItemOwnershipPolicy() {
         return itemOwnershipPolicy;
     }
-   
+
+    public @Nonnull MailOptions getMailOptions() {
+        return mailOptions != null ? mailOptions : MailOptions.DEFAULT;
+    }
+    
     @Override
     public Descriptor<OwnershipPluginConfiguration> getDescriptor() {
         return DESCRIPTOR;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/OwnershipLayoutFormatterProvider.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/OwnershipLayoutFormatterProvider.java
@@ -27,6 +27,7 @@ package com.synopsys.arc.jenkins.plugins.ownership.extensions;
 import com.synopsys.arc.jenkins.plugins.ownership.util.ui.OwnershipLayoutFormatter;
 import hudson.model.Job;
 import hudson.model.Node;
+import hudson.model.Run;
 import javax.annotation.Nonnull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -42,6 +43,7 @@ public abstract class OwnershipLayoutFormatterProvider {
     public static final OwnershipLayoutFormatterProvider DEFAULT_PROVIDER = new DefaultProvider();
     private static final OwnershipLayoutFormatter<Job<?,?>> DEFAULT_JOB_FORMATTER = new OwnershipLayoutFormatter.DefaultJobFormatter<Job<?,?>>();
     private static final OwnershipLayoutFormatter<Node> DEFAULT_NODE_FORMATTER = new OwnershipLayoutFormatter.DefaultJobFormatter<Node>();
+    private static final OwnershipLayoutFormatter<Run> DEFAULT_RUN_FORMATTER = new OwnershipLayoutFormatter.DefaultJobFormatter<Run>();
     
     public @Nonnull OwnershipLayoutFormatter<Job<?,?>> getLayoutFormatter(@Nonnull Job<?,?> job) {
         return DEFAULT_JOB_FORMATTER;
@@ -50,6 +52,11 @@ public abstract class OwnershipLayoutFormatterProvider {
     public @Nonnull OwnershipLayoutFormatter<Node> getLayoutFormatter(@Nonnull Node node) {
         return DEFAULT_NODE_FORMATTER;
     }
+    
+    public @Nonnull OwnershipLayoutFormatter<Run> getLayoutFormatter(@Nonnull Run run) {
+        return DEFAULT_RUN_FORMATTER;
+    }
+    
     
     public static final class DefaultProvider extends OwnershipLayoutFormatterProvider {        
     }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
@@ -128,9 +128,15 @@ public class JobOwnerHelper extends AbstractOwnershipHelper<Job<?,?>> {
             return User.getAll();
         }
     }  
-
-    public String getItemSummary(Job<?, ?> item) {
-        return "job "+item.getFullDisplayName();
+   
+    @Override
+    public String getItemTypeName(Job<?, ?> item) {
+        return "job";
+    }
+    
+    @Override
+    public String getItemDisplayName(Job<?, ?> item) {
+        return item.getFullDisplayName();
     }
 
     public String getItemURL(Job<?, ?> item) {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
@@ -47,7 +47,7 @@ import javax.annotation.Nonnull;
 public class JobOwnerHelper extends AbstractOwnershipHelper<Job<?,?>> {
     
     public final static JobOwnerHelper Instance = new JobOwnerHelper();
-    
+      
     /**
      * Gets JobOwnerProperty from job if possible.
      * The function also handles multi-configuration jobs, so it should be used 
@@ -128,4 +128,12 @@ public class JobOwnerHelper extends AbstractOwnershipHelper<Job<?,?>> {
             return User.getAll();
         }
     }  
+
+    public String getItemSummary(Job<?, ?> item) {
+        return "job "+item.getFullDisplayName();
+    }
+
+    public String getItemURL(Job<?, ?> item) {
+        return item.getUrl();
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
@@ -71,4 +71,13 @@ public class ComputerOwnerHelper extends AbstractOwnershipHelper<Computer> {
         
         NodeOwnerHelper.setOwnership(node, descr);
     }
+
+    public String getItemSummary(Computer item) {
+        return "computer "+item.getDisplayName();
+    }
+
+    public String getItemURL(Computer item) {
+        //TODO: Absolute URL
+        return item.getUrl();
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
@@ -72,8 +72,13 @@ public class ComputerOwnerHelper extends AbstractOwnershipHelper<Computer> {
         NodeOwnerHelper.setOwnership(node, descr);
     }
 
-    public String getItemSummary(Computer item) {
-        return "computer "+item.getDisplayName();
+    @Override
+    public String getItemTypeName(Computer item) {
+        return "computer";
+    }
+
+    public String getItemDisplayName(Computer item) {
+        return item.getDisplayName();
     }
 
     public String getItemURL(Computer item) {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
@@ -96,4 +96,13 @@ public class NodeOwnerHelper extends AbstractOwnershipHelper<Node> {
             prop.setOwnershipDescription(descr);
         }
     }
+
+    public String getItemSummary(Node item) {
+        return "node "+item.getDisplayName();
+    }
+
+    public String getItemURL(Node item) {
+        Computer c = item.toComputer();
+        return c != null ? ComputerOwnerHelper.Instance.getItemURL(c) : null;
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
@@ -48,6 +48,7 @@ import javax.annotation.Nonnull;
 public class NodeOwnerHelper extends AbstractOwnershipHelper<Node> {
 
     public static final NodeOwnerHelper Instance = new NodeOwnerHelper();
+    /**package*/ static final String ITEM_TYPE_NAME = "node";
 
     /**
      * Gets OwnerNodeProperty from job if possible.
@@ -97,10 +98,17 @@ public class NodeOwnerHelper extends AbstractOwnershipHelper<Node> {
         }
     }
 
-    public String getItemSummary(Node item) {
-        return "node "+item.getDisplayName();
+    @Override
+    public String getItemTypeName(Node item) {
+        return ITEM_TYPE_NAME;
+    }
+    
+    @Override
+    public String getItemDisplayName(Node item) {
+        return item.getDisplayName();
     }
 
+    @Override
     public String getItemURL(Node item) {
         Computer c = item.toComputer();
         return c != null ? ComputerOwnerHelper.Instance.getItemURL(c) : null;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
@@ -80,12 +80,19 @@ public class NodeOwnerPropertyHelper extends AbstractOwnershipHelper<NodePropert
         }
         return null;
     }
+
+    @Override
+    public String getItemTypeName(NodeProperty item) {
+        return NodeOwnerHelper.ITEM_TYPE_NAME;
+    }
     
-    public String getItemSummary(NodeProperty item) { 
+    @Override
+    public String getItemDisplayName(NodeProperty item) { 
         Node node = getNode(item);
-        return node != null ? NodeOwnerHelper.Instance.getItemSummary(node) : "unknown node";
+        return node != null ? NodeOwnerHelper.Instance.getItemDisplayName(node) : "unknown node";
     }
 
+    @Override
     public String getItemURL(NodeProperty item) {
         Node node = getNode(item);
         return node != null ? NodeOwnerHelper.Instance.getItemURL(node) : null;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
@@ -27,6 +27,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserCollectionFilter;
+import hudson.model.Node;
 import hudson.model.User;
 import hudson.slaves.NodeProperty;
 import java.util.Collection;
@@ -45,7 +46,7 @@ public class NodeOwnerPropertyHelper extends AbstractOwnershipHelper<NodePropert
 
     /**
      * Gets OwnerNodeProperty from job if possible
-     * @param node Node
+     * @param node Node property
      * @return OwnerNodeProperty or null
      */
     @CheckForNull
@@ -71,6 +72,22 @@ public class NodeOwnerPropertyHelper extends AbstractOwnershipHelper<NodePropert
             return User.getAll();
         }
     }   
+
+    private @CheckForNull Node getNode(@Nonnull NodeProperty item){
+        if (item instanceof OwnerNodeProperty) {
+            OwnerNodeProperty prop = (OwnerNodeProperty) item;
+            return prop.getNode();
+        }
+        return null;
+    }
     
-      
+    public String getItemSummary(NodeProperty item) { 
+        Node node = getNode(item);
+        return node != null ? NodeOwnerHelper.Instance.getItemSummary(node) : "unknown node";
+    }
+
+    public String getItemURL(NodeProperty item) {
+        Node node = getNode(item);
+        return node != null ? NodeOwnerHelper.Instance.getItemURL(node) : null;
+    }     
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -26,6 +26,7 @@ package com.synopsys.arc.jenkins.plugins.ownership.util;
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.Messages;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.mail.MailFormatter;
 import hudson.model.User;
 import java.io.UnsupportedEncodingException;
@@ -91,7 +92,13 @@ public abstract class AbstractOwnershipHelper<TObjectType>
             // Cannot construct e-mail if Jenkins has not been initialized
             return null;
         }
-
+        OwnershipPlugin plugin = instance.getPlugin(OwnershipPlugin.class);
+        if (plugin == null) {
+            // Plugin is not initialized
+            assert false : "Ownership plugin has not been loaded yet";
+            return null;
+        }
+        
         OwnershipDescription ownershipDescription = getOwnershipDescription(item);
         if (!ownershipDescription.isOwnershipEnabled()) {
             return null;
@@ -125,10 +132,11 @@ public abstract class AbstractOwnershipHelper<TObjectType>
                 ? user.getFullName() : "TODO: user name";
         final String relativeUrl = getItemURL(item);
         final String itemUrl = relativeUrl != null ? instance.getRootUrl()+relativeUrl : "unknown";
+        final String emailSubjectPrefix = plugin.getConfiguration().getMailOptions().getEmailSubjectPrefix();
         
         //TODO: make header configurable
         String subject = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailSubjectTemplate
-            ("[Jenkins] - On ", getItemSummary(item));
+            (emailSubjectPrefix, getItemSummary(item));
         String body = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailBodyTemplate(
             getItemSummary(item), itemUrl, userName);
 

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -24,12 +24,19 @@
 package com.synopsys.arc.jenkins.plugins.ownership.util;
 
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.Messages;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.util.mail.MailFormatter;
 import hudson.model.User;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
 
 /**
  * Provides basic operations for ownership helpers.
@@ -38,11 +45,12 @@ import javax.annotation.Nonnull;
  * @author Oleg Nenashev <nenashev@synopsys.com>
  */
 public abstract class AbstractOwnershipHelper<TObjectType>  
-    implements IOwnershipHelper<TObjectType>  
-{
+    implements IOwnershipHelper<TObjectType> {
+    
     /**An empty collection of users*/
     protected final static Collection<User> EMPTY_USERS_COLLECTION = new ArrayList<User>(0);
-            
+    private static final MailFormatter MAIL_FORMATTER = new MailFormatter();
+    
     @Override
     public final @Nonnull String getDisplayName(@CheckForNull User usr) {
         return UserStringFormatter.format(usr);
@@ -74,5 +82,62 @@ public abstract class AbstractOwnershipHelper<TObjectType>
     public final boolean isOwnerExists(@Nonnull TObjectType item) {
         OwnershipDescription descr = getOwnershipDescription(item);
         return descr.isOwnershipEnabled() ? descr.hasPrimaryOwner() : false;
+    }
+
+    @Override
+    public String getContactOwnersMailToURL(TObjectType item) {
+        final Jenkins instance = Jenkins.getInstance();
+        if (instance == null) {
+            // Cannot construct e-mail if Jenkins has not been initialized
+            return null;
+        }
+
+        OwnershipDescription ownershipDescription = getOwnershipDescription(item);
+        if (!ownershipDescription.isOwnershipEnabled()) {
+            return null;
+        }
+
+        // to - job owner
+        List<String> to = null;
+        if (ownershipDescription.hasPrimaryOwner()) {
+            String email = UserStringFormatter.formatEmail(ownershipDescription.getPrimaryOwnerId());
+            if (email != null) {
+                to = Arrays.asList(email);
+            }
+        }
+
+        // cc - job co-owners
+        List<String> cc = null;
+        final Set<String> coOwners = ownershipDescription.getCoownersIds();
+        if (!coOwners.isEmpty()) {
+            cc = new ArrayList<String>(coOwners.size());
+            for (String coOwnerId : coOwners) {
+                String email = UserStringFormatter.formatEmail(coOwnerId);
+                if (email != null) {
+                    cc.add(email);
+                }
+            }
+        }
+
+        // Prepare subject and body using formatters
+        final User user = User.current();
+        final String userName = (user != null && user != User.getUnknown())
+                ? user.getFullName() : "TODO: user name";
+        final String relativeUrl = getItemURL(item);
+        final String itemUrl = relativeUrl != null ? instance.getRootUrl()+relativeUrl : "unknown";
+        
+        //TODO: make header configurable
+        String subject = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailSubjectTemplate
+            ("[Jenkins] - On ", getItemSummary(item));
+        String body = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailBodyTemplate(
+            getItemSummary(item), itemUrl, userName);
+
+        try {
+            final String formattedURL = MAIL_FORMATTER.createMailToString(
+                to, cc, null, subject, body);
+            return formattedURL;
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException("Unsupported encoding: "+MAIL_FORMATTER.getEncoding(), ex);
+        }    
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -84,4 +84,9 @@ public abstract class AbstractOwnershipHelper<TObjectType>
         OwnershipDescription descr = getOwnershipDescription(item);
         return descr.isOwnershipEnabled() ? descr.hasPrimaryOwner() : false;
     }
+
+    @Override
+    public Collection<User> getPossibleOwners(TObjectType item) {
+        return EMPTY_USERS_COLLECTION;
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatter.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.synopsys.arc.jenkins.plugins.ownership.util.mail;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.apache.http.NameValuePair;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+
+/**
+ * Provides the support of operations with e-mails.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @since 0.6
+ */
+public class MailFormatter {
+    
+    private static final String DEFAULT_ENCODING = "UTF-8";
+    private static final String DEFAULT_SEPARATOR= ";";
+    
+    private final String encoding;
+    private final String separator;
+
+    public MailFormatter() {
+        this (DEFAULT_ENCODING, DEFAULT_SEPARATOR);
+    }
+  
+    public MailFormatter(String encoding, String separator) {
+        this.encoding = encoding;
+        this.separator = separator;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public String getSeparator() {
+        return separator;
+    }
+       
+    public @Nonnull String createMailToString (
+            @CheckForNull List<String> to, 
+            @CheckForNull List<String> cc, 
+            @CheckForNull List<String> bcc, 
+            @CheckForNull String subject, 
+            @CheckForNull String body) throws UnsupportedEncodingException {
+        StringBuilder b = new StringBuilder("mailto:");
+        String toString = joinMailAddresses(to);
+        if (toString != null) {
+            b.append(URLEncoder.encode(toString, encoding));
+        }
+        List<NameValuePair> params = new LinkedList<NameValuePair>();
+        joinMailAddresses(cc, "cc", params);
+        joinMailAddresses(bcc, "bcc", params);
+        if (subject != null) {
+            params.add(new BasicNameValuePair("subject", subject));
+        }
+        if (body != null) {
+            params.add(new BasicNameValuePair("body", body));
+        }
+        if (!params.isEmpty()) {
+            b.append("?");
+            String encodedParams = URLEncodedUtils.format(params, encoding);
+            encodedParams = encodedParams.replace("+","%20");
+            b.append(encodedParams);
+        }
+        return b.toString();
+    }
+    
+    private @CheckForNull String joinMailAddresses (@CheckForNull List<String> items) {
+        if (items != null && items.size() > 0) {
+            return StringUtils.join(items, separator);
+        } 
+        return null;
+    }
+    
+    private void joinMailAddresses (@CheckForNull List<String> items, 
+            @CheckForNull String paramName, @Nonnull List<NameValuePair> target) 
+            throws UnsupportedEncodingException {
+        final String res = joinMailAddresses(items);
+        if (res != null) {
+           // final String encodedValue = URLEncoder.encode(res, encoding);
+           target.add(new BasicNameValuePair(paramName, res));
+        }
+    }
+    
+}

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatter.java
@@ -43,25 +43,28 @@ import org.apache.http.message.BasicNameValuePair;
 public class MailFormatter {
     
     private static final String DEFAULT_ENCODING = "UTF-8";
-    private static final String DEFAULT_SEPARATOR= ";";
     
-    private final String encoding;
-    private final String separator;
+    private final @Nonnull String encoding;
+    private final @Nonnull String separator;
 
     public MailFormatter() {
-        this (DEFAULT_ENCODING, DEFAULT_SEPARATOR);
+        this (DEFAULT_ENCODING, MailOptions.DEFAULT.getEmailListSeparator());
     }
   
-    public MailFormatter(String encoding, String separator) {
+    public MailFormatter(@Nonnull String separator) {
+        this (DEFAULT_ENCODING, separator);
+    }
+    
+    public MailFormatter(@Nonnull String encoding, @Nonnull String separator) {
         this.encoding = encoding;
         this.separator = separator;
     }
 
-    public String getEncoding() {
+    public @Nonnull String getEncoding() {
         return encoding;
     }
 
-    public String getSeparator() {
+    public @Nonnull String getSeparator() {
         return separator;
     }
        
@@ -106,7 +109,6 @@ public class MailFormatter {
             throws UnsupportedEncodingException {
         final String res = joinMailAddresses(items);
         if (res != null) {
-           // final String encodedValue = URLEncoder.encode(res, encoding);
            target.add(new BasicNameValuePair(paramName, res));
         }
     }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.synopsys.arc.jenkins.plugins.ownership.util.mail;
+
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Stores mailing options for {@link OwnershipPlugin}.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @since 0.6
+ */
+public class MailOptions implements Describable<MailOptions> {
+    
+    private final @CheckForNull String emailSubjectPrefix;
+    private final @CheckForNull String adminsContactEmail;
+    private final @CheckForNull String adminsEmailPrefix;
+
+    private static final String DEFAULT_SUBJECT_PREFIX = "[Jenkins] - ";
+    private static final String DEFAULT_ADMINS_EMAIL_PREFIX = "Dear Jenkins admins,";
+    public static final MailOptions DEFAULT = new MailOptions(DEFAULT_SUBJECT_PREFIX, null, 
+            DEFAULT_ADMINS_EMAIL_PREFIX);
+    
+    @DataBoundConstructor
+    public MailOptions(String emailSubjectPrefix, String adminsContactEmail, String adminsEmailPrefix) {
+        this.emailSubjectPrefix = hudson.Util.fixEmptyAndTrim(emailSubjectPrefix);
+        this.adminsContactEmail = hudson.Util.fixEmptyAndTrim(adminsContactEmail);
+        this.adminsEmailPrefix = hudson.Util.fixEmptyAndTrim(adminsEmailPrefix);
+    }
+
+    public @Nonnull String getEmailSubjectPrefix() {
+        return emailSubjectPrefix != null ? emailSubjectPrefix : DEFAULT_SUBJECT_PREFIX;
+    }
+
+    public @CheckForNull String getAdminsContactEmail() {
+        return adminsContactEmail;
+    }
+
+    public @Nonnull String getAdminsEmailPrefix() {
+        return adminsEmailPrefix != null ? adminsEmailPrefix : DEFAULT_ADMINS_EMAIL_PREFIX;
+    }
+
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
+    }
+  
+    public static class DescriptorImpl extends Descriptor<MailOptions> {
+        
+        @Override
+        public String getDisplayName() {
+            return "N/A";
+        }
+    }
+}

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
@@ -40,23 +40,32 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class MailOptions implements Describable<MailOptions> {
     
     private final @CheckForNull String emailSubjectPrefix;
+    private final @CheckForNull String emailListSeparator;
     private final @CheckForNull String adminsContactEmail;
     private final @CheckForNull String adminsEmailPrefix;
-
+    
     private static final String DEFAULT_SUBJECT_PREFIX = "[Jenkins] - ";
+    private static final String DEFAULT_LIST_SEPARATOR = ";";
     private static final String DEFAULT_ADMINS_EMAIL_PREFIX = "Dear Jenkins admins,";
+     
     public static final MailOptions DEFAULT = new MailOptions(DEFAULT_SUBJECT_PREFIX, null, 
-            DEFAULT_ADMINS_EMAIL_PREFIX);
+            DEFAULT_ADMINS_EMAIL_PREFIX, DEFAULT_LIST_SEPARATOR);
     
     @DataBoundConstructor
-    public MailOptions(String emailSubjectPrefix, String adminsContactEmail, String adminsEmailPrefix) {
+    public MailOptions(String emailSubjectPrefix, String adminsContactEmail, String adminsEmailPrefix, 
+            String emailListSeparator) {
         this.emailSubjectPrefix = hudson.Util.fixEmptyAndTrim(emailSubjectPrefix);
         this.adminsContactEmail = hudson.Util.fixEmptyAndTrim(adminsContactEmail);
         this.adminsEmailPrefix = hudson.Util.fixEmptyAndTrim(adminsEmailPrefix);
+        this.emailListSeparator=hudson.Util.fixEmptyAndTrim(emailListSeparator);
     }
 
     public @Nonnull String getEmailSubjectPrefix() {
         return emailSubjectPrefix != null ? emailSubjectPrefix : DEFAULT_SUBJECT_PREFIX;
+    }
+    
+    public @Nonnull String getEmailListSeparator() {
+        return emailListSeparator != null ? emailListSeparator : DEFAULT_LIST_SEPARATOR;
     }
 
     public @CheckForNull String getAdminsContactEmail() {
@@ -66,7 +75,7 @@ public class MailOptions implements Describable<MailOptions> {
     public @Nonnull String getAdminsEmailPrefix() {
         return adminsEmailPrefix != null ? adminsEmailPrefix : DEFAULT_ADMINS_EMAIL_PREFIX;
     }
-
+   
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions.java
@@ -39,41 +39,65 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class MailOptions implements Describable<MailOptions> {
     
-    private final @CheckForNull String emailSubjectPrefix;
+    private final @CheckForNull String contactOwnersSubjectTemplate;
+    private final @CheckForNull String contactOwnersBodyTemplate;
+    private final @CheckForNull String contactAdminsSubjectTemplate;
+    private final @CheckForNull String contactAdminsBodyTemplate;
+       
     private final @CheckForNull String emailListSeparator;
     private final @CheckForNull String adminsContactEmail;
-    private final @CheckForNull String adminsEmailPrefix;
     
-    private static final String DEFAULT_SUBJECT_PREFIX = "[Jenkins] - ";
     private static final String DEFAULT_LIST_SEPARATOR = ";";
-    private static final String DEFAULT_ADMINS_EMAIL_PREFIX = "Dear Jenkins admins,";
      
-    public static final MailOptions DEFAULT = new MailOptions(DEFAULT_SUBJECT_PREFIX, null, 
-            DEFAULT_ADMINS_EMAIL_PREFIX, DEFAULT_LIST_SEPARATOR);
+    public static final MailOptions DEFAULT = new MailOptions();
+
+    private MailOptions() {
+        this(null,null,null,null,null,DEFAULT_LIST_SEPARATOR);
+    }
     
     @DataBoundConstructor
-    public MailOptions(String emailSubjectPrefix, String adminsContactEmail, String adminsEmailPrefix, 
-            String emailListSeparator) {
-        this.emailSubjectPrefix = hudson.Util.fixEmptyAndTrim(emailSubjectPrefix);
-        this.adminsContactEmail = hudson.Util.fixEmptyAndTrim(adminsContactEmail);
-        this.adminsEmailPrefix = hudson.Util.fixEmptyAndTrim(adminsEmailPrefix);
-        this.emailListSeparator=hudson.Util.fixEmptyAndTrim(emailListSeparator);
+    public MailOptions(
+            String contactOwnersSubjectTemplate, String contactOwnersBodyTemplate, 
+            String contactAdminsSubjectTemplate, String contactAdminsBodyTemplate, 
+             String adminsContactEmail, String emailListSeparator) {
+        this.contactOwnersSubjectTemplate = contactOwnersSubjectTemplate;
+        this.contactOwnersBodyTemplate = contactOwnersBodyTemplate;
+        this.contactAdminsSubjectTemplate = contactAdminsSubjectTemplate;
+        this.contactAdminsBodyTemplate = contactAdminsBodyTemplate;
+        this.emailListSeparator = emailListSeparator;
+        this.adminsContactEmail = adminsContactEmail;
     }
-
-    public @Nonnull String getEmailSubjectPrefix() {
-        return emailSubjectPrefix != null ? emailSubjectPrefix : DEFAULT_SUBJECT_PREFIX;
+  
+    public @Nonnull String getContactOwnersSubjectTemplate() {
+        return contactOwnersSubjectTemplate != null 
+                ? contactOwnersSubjectTemplate 
+                : Messages.contactOwnersSubjectTemplate_default();
     }
     
+    public @Nonnull String getContactOwnersBodyTemplate() {
+        return contactOwnersBodyTemplate != null 
+                ? contactOwnersBodyTemplate 
+                : Messages.contactOwnersBodyTemplate_default();
+    }
+
+    public @Nonnull String getContactAdminsSubjectTemplate() {
+        return contactAdminsSubjectTemplate != null 
+                ? contactAdminsSubjectTemplate 
+                : Messages.contactAdminsSubjectTemplate_default();
+    }
+    
+    public @Nonnull String getContactAdminsBodyTemplate() {
+        return contactAdminsBodyTemplate != null 
+                ? contactAdminsBodyTemplate 
+                : Messages.contactAdminsBodyTemplate_default();
+    }
+  
     public @Nonnull String getEmailListSeparator() {
         return emailListSeparator != null ? emailListSeparator : DEFAULT_LIST_SEPARATOR;
     }
 
     public @CheckForNull String getAdminsContactEmail() {
         return adminsContactEmail;
-    }
-
-    public @Nonnull String getAdminsEmailPrefix() {
-        return adminsEmailPrefix != null ? adminsEmailPrefix : DEFAULT_ADMINS_EMAIL_PREFIX;
     }
    
     @Extension

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/OwnershipMailHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/OwnershipMailHelper.java
@@ -1,0 +1,154 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.synopsys.arc.jenkins.plugins.ownership.util.mail;
+
+import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.Messages;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.util.UserStringFormatter;
+import hudson.model.User;
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import jenkins.model.Jenkins;
+
+/**
+ *
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+public class OwnershipMailHelper {
+
+    private static final MailFormatter MAIL_FORMATTER = new MailFormatter();
+    
+    private static enum Mode { ContactOwners, ContactAdmins };
+
+    /**
+     * Generate a mailto URL, which allows to contact owners.
+     * This URL should define default subject and body.
+     * @param item 
+     * @return MailTo URL or null if it is not available
+     * @since 0.6
+     */
+    public static <TObjectType> String getContactOwnersMailToURL (TObjectType item, 
+            IOwnershipHelper<TObjectType> helper) {
+        return getMailToURL(item, helper, Mode.ContactOwners);
+    }
+    
+    public static <TObjectType> String getContactAdminsMailToURL (TObjectType item, 
+            IOwnershipHelper<TObjectType> helper) {
+        return getMailToURL(item, helper, Mode.ContactAdmins);
+    }
+    
+    private static <TObjectType> String getMailToURL (TObjectType item, 
+            IOwnershipHelper<TObjectType> helper, Mode mode) {
+    
+        final Jenkins instance = Jenkins.getInstance();
+        if (instance == null) {
+            // Cannot construct e-mail if Jenkins has not been initialized
+            return null;
+        }
+        OwnershipPlugin plugin = instance.getPlugin(OwnershipPlugin.class);
+        if (plugin == null) {
+            // Plugin is not initialized
+            assert false : "Ownership plugin has not been loaded yet";
+            return null;
+        }
+        
+        OwnershipDescription ownershipDescription = helper.getOwnershipDescription(item);
+        if (!ownershipDescription.isOwnershipEnabled()) {
+            return null;
+        }
+
+        List<String> to = new LinkedList<String>();
+        List<String> cc = new LinkedList<String>();
+        
+        // to - job owner
+        if (ownershipDescription.hasPrimaryOwner()) {
+            String email = UserStringFormatter.formatEmail(ownershipDescription.getPrimaryOwnerId());
+            if (email != null) {
+                switch (mode) {
+                   case ContactAdmins:
+                       cc.add(email);
+                       break;
+                   default:
+                       to.add(email);
+                }
+            }
+        }
+
+        // cc - job co-owners
+        final Set<String> coOwners = ownershipDescription.getCoownersIds();
+        if (!coOwners.isEmpty()) {
+            for (String coOwnerId : coOwners) {
+                String email = UserStringFormatter.formatEmail(coOwnerId);
+                if (email != null) {
+                    cc.add(email);
+                }
+            }
+        }
+
+        // Prepare subject and body using formatters
+        final User user = User.current();
+        final String userName = (user != null && user != User.getUnknown())
+                ? user.getFullName() : "TODO: user name";
+        final String relativeUrl = helper.getItemURL(item);
+        final String itemUrl = relativeUrl != null ? instance.getRootUrl()+relativeUrl : "unknown";
+        final String emailSubjectPrefix = plugin.getConfiguration().getMailOptions().getEmailSubjectPrefix();
+        
+        //TODO: make header configurable
+        String subject = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailSubjectTemplate
+            (emailSubjectPrefix, helper.getItemSummary(item));
+        
+        
+        String body;
+        switch (mode) {
+            case ContactOwners:
+                body = Messages.OwnershipPlugin_FloatingBox_ContactOwners_EmailBodyTemplate(
+                       helper.getItemSummary(item), itemUrl, userName);
+                break;
+            case ContactAdmins:
+                final String adminEmail = plugin.getConfiguration().getMailOptions().getAdminsContactEmail();
+                to.add(adminEmail);
+                final String adminEmailPrefix = plugin.getConfiguration().getMailOptions().getAdminsEmailPrefix();
+                body = Messages.OwnershipPlugin_FloatingBox_ContactAdmins_EmailBodyTemplate(
+                       adminEmailPrefix, itemUrl, userName);
+                break;
+            default:
+                assert false : "Unsupported mode " + mode;
+                throw new IllegalStateException("Mode "+mode+" is unsupported");
+        }
+        
+
+        try {
+            final String formattedURL = MAIL_FORMATTER.createMailToString(
+                to, cc, null, subject, body);
+            return formattedURL;
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException("Unsupported encoding: "+MAIL_FORMATTER.getEncoding(), ex);
+        }    
+    }
+}

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
@@ -24,6 +24,8 @@
 
 package com.synopsys.arc.jenkins.plugins.ownership.util.ui;
 
+import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.Messages;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.HTMLFormatter;
 import javax.annotation.Nonnull;
@@ -47,6 +49,14 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
     public String formatCoOwner(@Nonnull TObjectType item, String userId) {
         return formatUser(item, userId);
     }
+    
+    /**
+     * Formats URL, which allows to contact item owners
+     * @param item
+     * @param helper 
+     * @return HTML-formatted link or empty string
+     */
+    public abstract String formatContactOwnersLink(@Nonnull TObjectType item, IOwnershipHelper helper);
       
     /**
      * Default user formatter for {@link OwnershipPlugin}.
@@ -60,6 +70,14 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
             final String userEmail = HTMLFormatter.formatEmailURI(userId);
             final String userInfoHTML = userURI + (userEmail != null ? " " + userEmail : "");
             return userInfoHTML;
+        }
+
+        @Override
+        public String formatContactOwnersLink(TObjectType item, IOwnershipHelper helper) {
+            String url = helper.getContactOwnersMailToURL(item);
+            return url != null 
+                    ? "<a href=\""+url+"\">"+Messages.OwnershipPlugin_FloatingBox_ContactOwners_Title()+"</a>"
+                    : "";     
         }
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
@@ -28,6 +28,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.Messages;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.HTMLFormatter;
+import com.synopsys.arc.jenkins.plugins.ownership.util.mail.OwnershipMailHelper;
 import javax.annotation.Nonnull;
 
 /**
@@ -55,9 +56,19 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
      * @param item
      * @param helper 
      * @return HTML-formatted link or empty string
+     * @since 0.6
      */
     public abstract String formatContactOwnersLink(@Nonnull TObjectType item, IOwnershipHelper helper);
-      
+    
+    /**
+     * Formats URL, which allows to contact Jenkins admins.
+     * @param item
+     * @param helper 
+     * @return HTML-formatted link or empty string
+     * @since 0.6
+     */
+    public abstract String formatContactAdminsLink(@Nonnull TObjectType item, IOwnershipHelper helper);
+    
     /**
      * Default user formatter for {@link OwnershipPlugin}.
      * @param <TObjectType> 
@@ -74,10 +85,12 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
 
         @Override
         public String formatContactOwnersLink(TObjectType item, IOwnershipHelper helper) {
-            String url = helper.getContactOwnersMailToURL(item);
-            return url != null 
-                    ? "<a href=\""+url+"\">"+Messages.OwnershipPlugin_FloatingBox_ContactOwners_Title()+"</a>"
-                    : "";     
+            return OwnershipMailHelper.getContactOwnersMailToURL(item, helper);   
+        }
+        
+        @Override
+        public String formatContactAdminsLink(TObjectType item, IOwnershipHelper helper) {
+            return OwnershipMailHelper.getContactAdminsMailToURL(item, helper);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipAction.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.ownership.model.runs;
+
+import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.ItemOwnershipAction;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.util.ui.OwnershipLayoutFormatter;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.security.Permission;
+import javax.annotation.Nonnull;
+
+/**
+ * Displays ownership info for builds. 
+ * This implementation is a stub for summaries visualization.
+ * Currently, users cannot manage builds ownership.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @since 0.6
+ */
+public class RunOwnershipAction extends ItemOwnershipAction<Run>  {
+
+    public RunOwnershipAction(@Nonnull Run describedItem) {
+        super(describedItem);
+    }
+
+    @Override
+    public Permission getOwnerPermission() {
+        return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
+    }
+
+    @Override
+    public Permission getProjectSpecificPermission() {
+        return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
+    }
+
+    @Override
+    public boolean actionIsAvailable() {
+        return false; // We don't provide action links now
+    }
+
+    public IOwnershipHelper<Run> helper() {
+        return RunOwnershipHelper.getInstance();
+    }
+    
+    public OwnershipLayoutFormatter<Run> getLayoutFormatter() {
+        return OwnershipPlugin.getInstance().getOwnershipLayoutFormatterProvider().getLayoutFormatter(getDescribedItem());
+    }   
+    
+}

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.ownership.model.runs;
+
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
+import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
+import hudson.model.Run;
+
+/**
+ * Helper for {@link Run} ownership management.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @since 0.6
+ */
+public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
+
+    private static final RunOwnershipHelper instance = new RunOwnershipHelper();
+
+    public static RunOwnershipHelper getInstance() {
+        return instance;
+    }
+    
+    @Override
+    public String getItemSummary(Run item) {
+        return "run "+item.getFullDisplayName();
+    }
+
+    @Override
+    public String getItemURL(Run item) {
+        return item.getUrl();
+    }
+
+    @Override
+    public OwnershipDescription getOwnershipDescription(Run item) {
+        return JobOwnerHelper.Instance.getOwnershipDescription(item.getParent());
+    }    
+}

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -41,10 +41,15 @@ public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
     public static RunOwnershipHelper getInstance() {
         return instance;
     }
+
+    @Override
+    public String getItemTypeName(Run item) {
+        return "run";
+    }
     
     @Override
-    public String getItemSummary(Run item) {
-        return "run "+item.getFullDisplayName();
+    public String getItemDisplayName(Run item) {
+        return item.getFullDisplayName();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipListener.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.ownership.model.runs;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+
+/**
+ * Injects {@link RunOwnershipAction}s to all runs.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @since 0.6
+ */
+@Extension
+public class RunOwnershipListener extends RunListener<Run> {
+ 
+    @Override
+    public void onStarted(Run r, TaskListener listener) {
+        if (r.getAction(RunOwnershipAction.class) == null) {
+            r.addAction(new RunOwnershipAction(r));
+        }
+    }
+    
+    // TODO: Add actions to previously created builds (?)
+}

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -4,18 +4,7 @@ OwnershipPlugin.ManagePermissions.SlaveDescription=Manage node ownership(set own
 OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership(set owners and co-owners)
 
 OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
-OwnershipPlugin.FloatingBox.ContactOwners.EmailSubjectTemplate= \
-{0} TODO: Describe the issue with {1}
-OwnershipPlugin.FloatingBox.ContactOwners.EmailBodyTemplate= \
-Dear owners of {0},\n\n\
-TODO: Add text\n\
-URL: {1}\n\n\
-Best regards,\n{2} 
-OwnershipPlugin.FloatingBox.ContactAdmins.EmailBodyTemplate= \
-{0}\n\n\
-TODO: Describe the issue\n\
-URL: {1}\n\n\
-Best regards,\n{2} 
+
 
 JobOwnership.Config.SectionTitle=Job ownership
 JobOwnership.Column.Title=Job Owner

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -3,6 +3,15 @@ OwnershipPlugin.ManagePermissions.Title=Manage ownership
 OwnershipPlugin.ManagePermissions.SlaveDescription=Manage node ownership(set owners and co-owners)
 OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership(set owners and co-owners)
 
+OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
+OwnershipPlugin.FloatingBox.ContactOwners.EmailSubjectTemplate= \
+{0}{1}
+OwnershipPlugin.FloatingBox.ContactOwners.EmailBodyTemplate= \
+Dear owners of {0},\n\n\
+TODO: Add text\n\
+URL: {1}\n\n\
+Best regards,\n{2} 
+
 JobOwnership.Config.SectionTitle=Job ownership
 JobOwnership.Column.Title=Job Owner
 JobOwnership.Filter.DisplayName=Ownership Filter

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -5,7 +5,7 @@ OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership(set owner
 
 OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
 OwnershipPlugin.FloatingBox.ContactOwners.EmailSubjectTemplate= \
-{0} {1}
+{0} TODO: Describe the issue with {1}
 OwnershipPlugin.FloatingBox.ContactOwners.EmailBodyTemplate= \
 Dear owners of {0},\n\n\
 TODO: Add text\n\

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -11,6 +11,11 @@ Dear owners of {0},\n\n\
 TODO: Add text\n\
 URL: {1}\n\n\
 Best regards,\n{2} 
+OwnershipPlugin.FloatingBox.ContactAdmins.EmailBodyTemplate= \
+{0}\n\n\
+TODO: Describe the issue\n\
+URL: {1}\n\n\
+Best regards,\n{2} 
 
 JobOwnership.Config.SectionTitle=Job ownership
 JobOwnership.Column.Title=Job Owner

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -5,7 +5,7 @@ OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership(set owner
 
 OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
 OwnershipPlugin.FloatingBox.ContactOwners.EmailSubjectTemplate= \
-{0}{1}
+{0} {1}
 OwnershipPlugin.FloatingBox.ContactOwners.EmailBodyTemplate= \
 Dear owners of {0},\n\n\
 TODO: Add text\n\

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -70,5 +70,10 @@
                 </tr>
             </j:if>
         </table>
+        
+        <!-- Contact link -->
+        <div class="ownership-contact-links"> 
+            ${layoutFormatter.formatContactOwnersLink(item,helper)}
+        </div>
     </div>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -70,16 +70,16 @@
                 </tr>
             </j:if>
         </table>
-        
-        <!-- Contact Owners link -->
+             
         <div class="ownership-contact-links"> 
             <table>
                 <tr>  
+                    <!-- Contact Owners link -->
                     <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
                     <j:if test="${ownersMailToLink != null}">   
                         <td>    
                             <img src="${imagesURL}/24x24/user.png"/>
-                            <a href="${ownersMailToLink}">${%E-mail to owners}</a>
+                            <a href="${ownersMailToLink}">${%ownersMailToLink.text(itemType)}</a>
                         </td>
                     </j:if>
 
@@ -88,7 +88,7 @@
                     <j:if test="${adminsMailToLink != null}">
                         <td>
                             <img src="${imagesURL}/24x24/setting.png"/>
-                            <a href="${adminsMailToLink}">${%E-mail to service admins}</a>
+                            <a href="${adminsMailToLink}">${%adminsMailToLink.text}</a>
                         </td>
                     </j:if>
                 </tr>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -72,19 +72,27 @@
         </table>
         
         <!-- Contact Owners link -->
-        <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
-        <j:if test="${ownersMailToLink != null}">
-            <div class="contact-owners-links"> 
-                <a href="${ownersMailToLink}">${%Contact owners}</a>
-            </div>
-        </j:if>
-        
-        <!-- Contact Admins link -->
-        <j:set var="adminsMailToLink" value="${layoutFormatter.formatContactAdminsLink(item,helper)}"/>
-        <j:if test="${adminsMailToLink != null}">
-            <div class="contact-admins-links"> 
-                <a href="${adminsMailToLink}">${%Contact service admins}</a>
-            </div>
-        </j:if>
+        <div class="ownership-contact-links"> 
+            <table>
+                <tr>  
+                    <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
+                    <j:if test="${ownersMailToLink != null}">   
+                        <td>    
+                            <img src="${imagesURL}/24x24/user.png"/>
+                            <a href="${ownersMailToLink}">${%E-mail to owners}</a>
+                        </td>
+                    </j:if>
+
+                    <!-- Contact Admins link -->
+                    <j:set var="adminsMailToLink" value="${layoutFormatter.formatContactAdminsLink(item,helper)}"/>
+                    <j:if test="${adminsMailToLink != null}">
+                        <td>
+                            <img src="${imagesURL}/24x24/setting.png"/>
+                            <a href="${adminsMailToLink}">${%E-mail to service admins}</a>
+                        </td>
+                    </j:if>
+                </tr>
+            </table>
+        </div>
     </div>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -71,9 +71,20 @@
             </j:if>
         </table>
         
-        <!-- Contact link -->
-        <div class="ownership-contact-links"> 
-            ${layoutFormatter.formatContactOwnersLink(item,helper)}
-        </div>
+        <!-- Contact Owners link -->
+        <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
+        <j:if test="${ownersMailToLink != null}">
+            <div class="contact-owners-links"> 
+                <a href="${ownersMailToLink}">${%Contact owners}</a>
+            </div>
+        </j:if>
+        
+        <!-- Contact Admins link -->
+        <j:set var="adminsMailToLink" value="${layoutFormatter.formatContactAdminsLink(item,helper)}"/>
+        <j:if test="${adminsMailToLink != null}">
+            <div class="contact-admins-links"> 
+                <a href="${adminsMailToLink}">${%Contact service admins}</a>
+            </div>
+        </j:if>
     </div>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
@@ -1,0 +1,2 @@
+ownersMailToLink.text=E-mail to {0} owners
+adminsMailToLink.text=E-mail to Service owners

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -26,7 +26,7 @@
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     
-    <f:entry title="${%Admins e-mail}" field="adminsContactEmail">
+    <f:entry title="${%Service owners e-mail}" field="adminsContactEmail">
         <f:textbox/> 
     </f:entry>  
     <f:advanced title="${%Advanced e-mail options}">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -25,13 +25,19 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${%Subject prefix}" field="emailSubjectPrefix">
-        <f:textbox/> 
-    </f:entry>
+    
     <f:entry title="${%Admins contact}" field="adminsContactEmail">
         <f:textbox/> 
-    </f:entry>
-    <f:entry title="${%Admins e-mail prefix}" field="adminsEmailPrefix">
-        <f:textbox/> 
-    </f:entry>
+    </f:entry>  
+    <f:advanced title="${%Advanced e-mail options}">
+        <f:entry title="${%Subject prefix}" field="emailSubjectPrefix">
+            <f:textbox/> 
+        </f:entry>
+        <f:entry title="${%Admins e-mail prefix}" field="adminsEmailPrefix">
+            <f:textbox/> 
+        </f:entry>
+        <f:entry title="${%Recipients separator}" field="emailListSeparator">
+            <f:textbox/> 
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -26,7 +26,7 @@
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     
-    <f:entry title="${%Admins contact}" field="adminsContactEmail">
+    <f:entry title="${%Admins e-mail}" field="adminsContactEmail">
         <f:textbox/> 
     </f:entry>  
     <f:advanced title="${%Advanced e-mail options}">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -30,12 +30,19 @@
         <f:textbox/> 
     </f:entry>  
     <f:advanced title="${%Advanced e-mail options}">
-        <f:entry title="${%Subject prefix}" field="emailSubjectPrefix">
-            <f:textbox/> 
+        <f:entry title="${%contactOwnersSubjectTemplate.title}" field="contactOwnersSubjectTemplate">
+            <f:textbox default="${%contactOwnersSubjectTemplate.default}"/> 
         </f:entry>
-        <f:entry title="${%Admins e-mail prefix}" field="adminsEmailPrefix">
-            <f:textbox/> 
+        <f:entry title="${%contactOwnersBodyTemplate.title}" field="contactOwnersBodyTemplate">
+            <f:textarea default="${%contactOwnersBodyTemplate.default}"/> 
         </f:entry>
+        <f:entry title="${%contactAdminsSubjectTemplate.title}" field="contactAdminsSubjectTemplate">
+            <f:textbox default="${%contactAdminsSubjectTemplate.default}"/> 
+        </f:entry>
+        <f:entry title="${%contactAdminsBodyTemplate.title}" field="contactAdminsBodyTemplate">
+            <f:textarea default="${%contactAdminsBodyTemplate.default}"/>
+        </f:entry>
+   
         <f:entry title="${%Recipients separator}" field="emailListSeparator">
             <f:textbox/> 
         </f:entry>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2014 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2015 Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,14 +22,16 @@
  * THE SOFTWARE.
  -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
-     <j:invokeStatic var="itemOwnershipPolicies" 
-                    className="com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy"
-                    method="allDescriptors"/>
-    <f:entry>
-        <f:property field="mailOptions"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:entry title="${%Subject prefix}" field="emailSubjectPrefix">
+        <f:textbox/> 
     </f:entry>
-    <f:entry title="${%itemOwnershipPolicy.title}">
-        <f:hetero-radio field="itemOwnershipPolicy" descriptors="${itemOwnershipPolicies}"/>
+    <f:entry title="${%Admins contact}" field="adminsContactEmail">
+        <f:textbox/> 
+    </f:entry>
+    <f:entry title="${%Admins e-mail prefix}" field="adminsEmailPrefix">
+        <f:textbox/> 
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/config.properties
@@ -1,0 +1,4 @@
+contactOwnersSubjectTemplate.title=Item Owners Email Subject Template
+contactOwnersBodyTemplate.title=Item Owners Email Subject Template
+contactAdminsSubjectTemplate.title=Service Owners Email Subject Template
+contactAdminsBodyTemplate.title=Service Owners Email Body Template

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsContactEmail.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsContactEmail.html
@@ -1,0 +1,8 @@
+<div>
+    E-mail (or a list of e-mails), which will be used to contact Jenkins 
+    administrators from ownership controls.
+    <p/>
+    This option is designed to support individual users or mail lists, 
+    which may be unavailable within Jenkins Security Realm. 
+    You can also specify multiple users by using mail list separators. 
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsEmailPrefix.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsEmailPrefix.html
@@ -1,0 +1,5 @@
+<div>
+    First line of the e-mail body to service administrators.
+    <p/>
+    Currently, environment variables are not supported.
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsEmailPrefix.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-adminsEmailPrefix.html
@@ -1,5 +1,0 @@
-<div>
-    First line of the e-mail body to service administrators.
-    <p/>
-    Currently, environment variables are not supported.
-</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactAdminsBodyTemplate.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactAdminsBodyTemplate.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        E-mail body template for &quot;Contact Service Owners&quot; link.
+    </p>
+    <p>
+        The entry supports the variables substitution (see the list below). 
+        Missing variables won&#39;t be substituted.
+    </p>
+    <ul>
+        <li/><b>USER_ID</b> - ID of the current user
+        <li/><b>USER_FULL_NAME</b> - Full name of the current user
+        <li/><b>ITEM_TYPE_NAME</b> - Type name of the currently item (job, node, build, etc.)
+        <li/><b>ITEM_DISPLAY_NAME</b> - Display name of the item
+        <li/><b>ITEM_URL</b> - Absolute URL to the item (if exists) 
+    </ul>
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactAdminsSubjectTemplate.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactAdminsSubjectTemplate.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        E-mail subject template for &quot;Contact Service Owners&quot; link.
+    </p>
+    <p>
+        The entry supports the variables substitution (see the list below). 
+        Missing variables won&#39;t be substituted.
+    </p>
+    <ul>
+        <li/><b>USER_ID</b> - ID of the current user
+        <li/><b>USER_FULL_NAME</b> - Full name of the current user
+        <li/><b>ITEM_TYPE_NAME</b> - Type name of the currently item (job, node, build, etc.)
+        <li/><b>ITEM_DISPLAY_NAME</b> - Display name of the item
+        <li/><b>ITEM_URL</b> - Absolute URL to the item (if exists) 
+    </ul>
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactOwnersBodyTemplate.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactOwnersBodyTemplate.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        E-mail body template for &quot;Contact Item Owners&quot; link.
+    </p>
+    <p>
+        The entry supports the variables substitution (see the list below). 
+        Missing variables won&#39;t be substituted.
+    </p>
+    <ul>
+        <li/><b>USER_ID</b> - ID of the current user
+        <li/><b>USER_FULL_NAME</b> - Full name of the current user
+        <li/><b>ITEM_TYPE_NAME</b> - Type name of the currently item (job, node, build, etc.)
+        <li/><b>ITEM_DISPLAY_NAME</b> - Display name of the item
+        <li/><b>ITEM_URL</b> - Absolute URL to the item (if exists) 
+    </ul>
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactOwnersSubjectTemplate.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-contactOwnersSubjectTemplate.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        E-mail subject template for &quot;Contact Item Owners&quot; link.
+    </p>
+    <p>
+        The entry supports the variables substitution (see the list below). 
+        Missing variables won&#39;t be substituted.
+    </p>
+    <ul>
+        <li/><b>USER_ID</b> - ID of the current user
+        <li/><b>USER_FULL_NAME</b> - Full name of the current user
+        <li/><b>ITEM_TYPE_NAME</b> - Type name of the currently item (job, node, build, etc.)
+        <li/><b>ITEM_DISPLAY_NAME</b> - Display name of the item
+        <li/><b>ITEM_URL</b> - Absolute URL to the item (if exists) 
+    </ul>
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
@@ -1,6 +1,6 @@
 <div>
     Separator for e-mail recipients list (To, Cc, etc.). 
     <p/>
-    According to MailTo format standards, the default separator is comma (&#39,&#39), 
-    but several systems handle semi-colons (&#39&#59&#39) only.
+    According to MailTo format standards, the default separator is comma (&#39;,&#39;), 
+    but several systems handle semi-colons (&#39;&#59;&#39;) only.
 </div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
@@ -1,0 +1,5 @@
+<div>
+    Separator for e-mail recipients list (To, Cc, etc.). <br/>
+    According to MailTo format standards, the default separator is comma (&#39,&#39), 
+    but several systems handle semi-colons (&#39&#59&#39) only.
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailListSeparator.html
@@ -1,5 +1,6 @@
 <div>
-    Separator for e-mail recipients list (To, Cc, etc.). <br/>
+    Separator for e-mail recipients list (To, Cc, etc.). 
+    <p/>
     According to MailTo format standards, the default separator is comma (&#39,&#39), 
     but several systems handle semi-colons (&#39&#59&#39) only.
 </div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailSubjectPrefix.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailSubjectPrefix.html
@@ -1,0 +1,6 @@
+<div>
+    Prefix of e-mail subjects.
+    <p/>
+    This option is useful to setup different subject prefixes for Jenkins installations.
+    After that, users will be able to configure rules in their mail clients.
+</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailSubjectPrefix.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailOptions/help-emailSubjectPrefix.html
@@ -1,6 +1,0 @@
-<div>
-    Prefix of e-mail subjects.
-    <p/>
-    This option is useful to setup different subject prefixes for Jenkins installations.
-    After that, users will be able to configure rules in their mail clients.
-</div>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/util/mail/Messages.properties
@@ -1,0 +1,12 @@
+contactOwnersSubjectTemplate.default=[Jenkins] - TODO: Describe the issue with '${ITEM_TYPE_NAME} ${ITEM_DISPLAY_NAME}'
+contactOwnersBodyTemplate.default=\
+Dear owners of '${ITEM_TYPE_NAME} ${ITEM_DISPLAY_NAME}',\n\n\
+TODO: Add text\n\
+URL: '${ITEM_URL}'\n\n\
+Best regards,\n'${USER_FULL_NAME}' 
+contactAdminsSubjectTemplate.default=[Jenkins] - TODO: Describe the issue with '${ITEM_TYPE_NAME} ${ITEM_DISPLAY_NAME}'
+contactAdminsBodyTemplate.default=\
+Dear Jenkins admins,\n\n\
+TODO: Describe the issue\n\
+URL: '${ITEM_URL}'\n\n\
+Best regards,\n'${USER_FULL_NAME}'

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipAction/summary.jelly
@@ -1,0 +1,32 @@
+<!--
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ -->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <j:set var="item" value="${it.getDescribedItem()}"/>
+  <j:set var="helper" value="${it.helper()}"/>
+  <j:set var="itemType" value="Run"/>
+  <f:block>
+    <st:include page="floatingBoxTemplate.jelly" class="com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin" optional="false"/>      	
+  </f:block>
+</j:jelly>

--- a/src/main/webapp/css/ownership.css
+++ b/src/main/webapp/css/ownership.css
@@ -23,3 +23,8 @@
 .ownership-text {
     
 }
+
+.ownership-contact-links {
+    margin-left: 5px;
+    border-spacing: 5px;
+}

--- a/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatterTest.java
+++ b/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/util/mail/MailFormatterTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.synopsys.arc.jenkins.plugins.ownership.util.mail;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Tests for {@link MailFormatter}.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+public class MailFormatterTest {
+    
+    MailFormatter formatter = new MailFormatter();
+    
+    /**
+     * Just checks if nothing breaks horribly.
+     * @throws UnsupportedEncodingException Issues with the default encoding
+     * @throws MalformedURLException {@link MailFormatter} generated wrong link
+     */
+    public @Test void spotCheck() throws UnsupportedEncodingException, MalformedURLException {
+        String res = formatter.createMailToString(
+                Arrays.asList("test@foo.bar"), 
+                Arrays.asList("test1@foo.bar", "test2@foo.bar"), null, 
+                "[Jenkins] - Test subject", 
+                "Test body \n with multiple \r\n lines");
+        assertTrue(res.startsWith("mailto:"));
+        //TODO: check contents
+        final URL url = new URL(res);
+    }
+}


### PR DESCRIPTION
* Contact owners link appears in summary boxes (TODO: add image)
* If user clicks on the “mailto” link, he gets a pre-formatted e-mail stub
* Currently, links appear for jobs, nodes and new build runs

New summary with links:
![pane with a link](https://cloud.githubusercontent.com/assets/3000480/5648645/19476814-96a1-11e4-982e-9ac3718e5fa7.png)

![e-mail stub](https://cloud.githubusercontent.com/assets/3000480/5612843/51fd1ade-94ec-11e4-88a1-97ccdb92146b.png)