### PR TITLE
Bump core version to satisfy transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.3</version>
+        <version>1.532</version>
     </parent>
 
     <groupId>com.synopsys.jenkinsci</groupId>


### PR DESCRIPTION
ownership > authorize-project:1.0.2 > jenkins-core:1.532 (https://github.com/jenkinsci/authorize-project-plugin/blob/master/pom.xml#L6)

I am not even able to save the job from `hpi:run`:
```
java.lang.InstantiationException: file:/home/ogondza/code/jenkins/ownership-plugin/work/plugins/authorize-project/WEB-INF/classes/META-INF/annotations/hudson.Extension might need to be rebuilt: java.lang.ClassNotFoundException: org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator$DescriptorImpl
        at net.java.sezpoz.IndexItem.element(IndexItem.java:144)
        at hudson.ExtensionFinder$Sezpoz._find(ExtensionFinder.java:611)
        at hudson.ExtensionFinder$Sezpoz.find(ExtensionFinder.java:600)
        at hudson.ExtensionFinder._find(ExtensionFinder.java:151)
        at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:318)
        at hudson.ExtensionList.load(ExtensionList.java:295)
        at hudson.ExtensionList.ensureLoaded(ExtensionList.java:248)
        at hudson.ExtensionList.iterator(ExtensionList.java:138)
        at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:311)
        at hudson.ExtensionList.load(ExtensionList.java:295)
        at hudson.ExtensionList.ensureLoaded(ExtensionList.java:248)
        at hudson.ExtensionList.get(ExtensionList.java:153)
        at hudson.PluginManager$PluginUpdateMonitor.getInstance(PluginManager.java:1090)
        at hudson.maven.PluginImpl.init(PluginImpl.java:54)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at hudson.init.InitializerFinder.invoke(InitializerFinder.java:120)
        at hudson.init.InitializerFinder$TaskImpl.run(InitializerFinder.java:184)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:259)
        at jenkins.model.Jenkins$7.runTask(Jenkins.java:888)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:187)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:94)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator$DescriptorImpl
        at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:966)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
        at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
        ... 26 more
```