### PR TITLE
Remove unnecessary "//" from mailto scheme

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/HTMLFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/HTMLFormatter.java
@@ -50,7 +50,7 @@ public class HTMLFormatter {
     public static @CheckForNull String formatEmailURI(@Nonnull String userId) {
         String email = Functions.escape(UserStringFormatter.formatEmail(userId));
         if (email != null) {
-            return "<a href=\"mailto://"+email+"\">&lt;"+email+"&gt;</a>";
+            return "<a href=\"mailto:"+email+"\">&lt;"+email+"&gt;</a>";
         } else {
             return null;
         }          


### PR DESCRIPTION
I am not sure if current implementation works for some clients, but plain 'mailto:' should work everywhere.