### PR TITLE
[JENKINS-28714,JENKINS-28712] - Configurable display options for Ownership boxes

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
@@ -31,6 +31,7 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.ownership.config.DisplayOptions;
 import org.jenkinsci.plugins.ownership.model.runs.OwnershipRunListener;
 import org.jenkinsci.plugins.ownership.util.environment.EnvSetupOptions;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -45,6 +46,8 @@ public class OwnershipPluginConfiguration
 
     private final ItemOwnershipPolicy itemOwnershipPolicy;
     private final @CheckForNull MailOptions mailOptions;
+    private final @CheckForNull DisplayOptions displayOptions;
+    
     /**
      * Enforces the injection of ownership variables in {@link OwnershipRunListener}.
      * Null means the injection is disabled.
@@ -54,15 +57,23 @@ public class OwnershipPluginConfiguration
 
     @DataBoundConstructor
     public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy, 
-            @Nonnull MailOptions mailOptions, EnvSetupOptions globalEnvSetupOptions) {
+            @Nonnull MailOptions mailOptions, EnvSetupOptions globalEnvSetupOptions, 
+            @Nonnull DisplayOptions displayOptions) {
         this.itemOwnershipPolicy = itemOwnershipPolicy;
         this.mailOptions = mailOptions;
         this.globalEnvSetupOptions = globalEnvSetupOptions;
+        this.displayOptions = displayOptions;
     }
     
     @Deprecated
     public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy) {
         this (itemOwnershipPolicy, MailOptions.DEFAULT, null);
+    }
+    
+    @Deprecated
+    public OwnershipPluginConfiguration(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy, 
+            @Nonnull MailOptions mailOptions, EnvSetupOptions globalEnvSetupOptions) {
+        this(itemOwnershipPolicy, mailOptions, globalEnvSetupOptions, DisplayOptions.DEFAULT);
     }
 
     public @Nonnull ItemOwnershipPolicy getItemOwnershipPolicy() {
@@ -73,6 +84,16 @@ public class OwnershipPluginConfiguration
         return mailOptions != null ? mailOptions : MailOptions.DEFAULT;
     }
 
+    /**
+     * Gets {@link OwnershipPlugin}'s display options.
+     * @return Display options. If the configuration has not been specified after the plugin update,
+     *      {@link DisplayOptions#DEFAULT} will be returned.
+     * @since 0.8
+     */
+    public @Nonnull DisplayOptions getDisplayOptions() {
+        return displayOptions != null ? displayOptions : DisplayOptions.DEFAULT;
+    }
+    
     /**
      * @return Global environment inject options. Null - global setup is disabled
      * @since 0.6

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -98,6 +98,11 @@ public abstract class AbstractOwnershipHelper<TObjectType>
      * @since 0.8
      */
     public boolean isDisplayOwnershipSummaryBox(@Nonnull TObjectType item) {
+        // If there is no data, check global options
+        if (!getOwnershipDescription(item).isOwnershipEnabled()) {
+            return !OwnershipPlugin.getInstance().getConfiguration().getDisplayOptions().isHideOwnershipIfNoData();
+        }
+        
         return true;
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -89,4 +89,15 @@ public abstract class AbstractOwnershipHelper<TObjectType>
     public Collection<User> getPossibleOwners(TObjectType item) {
         return EMPTY_USERS_COLLECTION;
     }
+    
+    //TODO: promote to interface
+    /**
+     * Checks if the summary box should be displayed.
+     * @param item Current item
+     * @return {@code true} if the summary box should be displayed (even if there is no data); 
+     * @since 0.8
+     */
+    public boolean isDisplayOwnershipSummaryBox(@Nonnull TObjectType item) {
+        return true;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/config/DisplayOptions.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/config/DisplayOptions.java
@@ -31,6 +31,7 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.ownership.model.runs.RunOwnershipAction;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -41,17 +42,31 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class DisplayOptions implements Describable<DisplayOptions> {
        
-    public static final DisplayOptions DEFAULT = new DisplayOptions(false);
+    public static final DisplayOptions DEFAULT = new DisplayOptions(false, false);
     
     private final boolean hideRunOwnership;
+    private final boolean hideOwnershipIfNoData;
 
     @DataBoundConstructor
-    public DisplayOptions(boolean hideRunOwnership) {
+    public DisplayOptions(boolean hideRunOwnership, boolean hideOwnershipIfNoData) {
         this.hideRunOwnership = hideRunOwnership;
+        this.hideOwnershipIfNoData = hideOwnershipIfNoData;
     }
 
+    /**
+     * Disables Run summary boxes in {@link RunOwnershipAction}.
+     * @return {@code true} if {@link RunOwnershipAction}'s summary box should not be displayed.
+     */
     public boolean isHideRunOwnership() {
         return hideRunOwnership;
+    }
+
+    /**
+     * Does not display Ownership summary boxes if Ownership is not configured.
+     * @return {@code true} to hide empty Ownership summary boxes.
+     */
+    public boolean isHideOwnershipIfNoData() {
+        return hideOwnershipIfNoData;
     }
     
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/ownership/config/DisplayOptions.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/config/DisplayOptions.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Oleg Nenashev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.ownership.config;
+
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPluginConfiguration;
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Stores display options for {@link OwnershipPlugin}.
+ * This section is attached as an advanced section to {@link OwnershipPluginConfiguration}.
+ * @author Oleg Nenashev
+ * @since 0.8
+ */
+public class DisplayOptions implements Describable<DisplayOptions> {
+       
+    public static final DisplayOptions DEFAULT = new DisplayOptions(false);
+    
+    private final boolean hideRunOwnership;
+
+    @DataBoundConstructor
+    public DisplayOptions(boolean hideRunOwnership) {
+        this.hideRunOwnership = hideRunOwnership;
+    }
+
+    public boolean isHideRunOwnership() {
+        return hideRunOwnership;
+    }
+    
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
+    }
+  
+    public static class DescriptorImpl extends Descriptor<DisplayOptions> {
+        
+        @Override
+        public String getDisplayName() {
+            return "N/A";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -137,6 +137,7 @@ public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
 
     @Override
     public boolean isDisplayOwnershipSummaryBox(Run item) {
-        return !OwnershipPlugin.getInstance().getConfiguration().getDisplayOptions().isHideRunOwnership();
+        return super.isDisplayOwnershipSummaryBox(item) &&
+               !OwnershipPlugin.getInstance().getConfiguration().getDisplayOptions().isHideRunOwnership();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -25,6 +25,8 @@
 package org.jenkinsci.plugins.ownership.model.runs;
 
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPluginConfiguration;
 import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty;
 import com.synopsys.arc.jenkins.plugins.ownership.nodes.OwnerNodeProperty;
@@ -131,5 +133,10 @@ public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
         }
         target.put(prefix+"_COOWNERS", coowners.toString());
         target.put(prefix+"_COOWNERS_EMAILS", coownerEmails.toString());     
+    }
+
+    @Override
+    public boolean isDisplayOwnershipSummaryBox(Run item) {
+        return !OwnershipPlugin.getInstance().getConfiguration().getDisplayOptions().isHideRunOwnership();
     }
 }

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -39,7 +39,8 @@
     <j:set var="layoutFormatter" value="${it.layoutFormatter}"/>
     
     <!-- Layout -->
-    <div class="ownership-summary-box">   
+    <j:if test="${helper.isDisplayOwnershipSummaryBox(item)}">
+      <div class="ownership-summary-box">   
         <div class="ownership-header">${itemType} ${%Ownership}</div>            
         <table>
             <tr>
@@ -94,5 +95,6 @@
                 </tr>
             </table>
         </div>
-    </div>
+      </div>
+    </j:if>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -37,9 +37,10 @@
     <!--Stuff-->
     <link rel="stylesheet" href="${rootURL}/plugin/ownership/css/ownership.css" type="text/css" />
     <j:set var="layoutFormatter" value="${it.layoutFormatter}"/>
-    
-    <!-- Layout -->
-    <j:if test="${helper.isDisplayOwnershipSummaryBox(item)}">
+    <j:set var="ownershipDescription" value="${helper.getOwnershipDescription(item)}"/>
+   
+    <!-- Layout for ownership with available data -->
+    <j:if test="${helper.isDisplayOwnershipSummaryBox(item) and ownershipDescription.ownershipEnabled}">
       <div class="ownership-summary-box">   
         <div class="ownership-header">${itemType} ${%Ownership}</div>            
         <table>
@@ -95,6 +96,14 @@
                 </tr>
             </table>
         </div>
+      </div>
+    </j:if>
+    
+    <!-- Layout for ownership with missing data -->
+    <j:if test="${helper.isDisplayOwnershipSummaryBox(item) and !ownershipDescription.ownershipEnabled}">
+      <div class="ownership-summary-box">   
+        <div class="ownership-header">${itemType} ${%Ownership}</div>
+        ${%noOwnership.info.text(itemType)}                
       </div>
     </j:if>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
@@ -1,2 +1,5 @@
 ownersMailToLink.text=E-mail to {0} owners
 adminsMailToLink.text=E-mail to Service owners
+
+noOwnership.info.text=Ownership is not configured for this {0}. \
+  It can be configured using the "Manage Ownership" link on the left menu if you have appropriate permissions.

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration/config.jelly
@@ -35,4 +35,7 @@
     <f:entry>
         <f:optionalProperty field="globalEnvSetupOptions" title="${%globalEnvSetupOptions.title}"/>
     </f:entry>
+    <f:entry>
+        <f:property field="displayOptions"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
@@ -26,6 +26,9 @@
   <f:advanced title="${%Ownership Display Options}">
     <f:entry title="" description="">
         <table width="100%">
+          <f:entry field="hideOwnershipIfNoData">
+            <f:checkbox title="${%Hide ownership info if there is no data}"/>
+          </f:entry>
           <f:entry field="hideRunOwnership">
             <f:checkbox title="${%Hide ownership info on Run pages}"/>
           </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
@@ -1,0 +1,35 @@
+<!--
+* The MIT License
+*
+* Copyright 2015 Oleg Nenashev
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:advanced title="${%Ownership Display Options}">
+    <f:entry title="" description="">
+        <table width="100%">
+          <f:entry field="hideRunOwnership">
+            <f:checkbox title="${%Hide ownership info on Run pages}"/>
+          </f:entry>
+        </table>   
+    </f:entry> 
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/help-hideOwnershipIfNoData.html
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/help-hideOwnershipIfNoData.html
@@ -1,0 +1,6 @@
+<div>
+  This option hides empty Ownership summary boxes.
+  <p/>
+  If enabled, Jenkins will not show Ownership info box if the data is missing.
+  If disabled, Jenkins will show a summary box with &quot;Ownership is not configured&quot;message.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/help-hideRunOwnership.html
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/help-hideRunOwnership.html
@@ -1,0 +1,3 @@
+<div>
+  Hides ownership info on Run pages. This option may be used to save some space on the page.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipActionTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ownership.model.runs;
+
+import com.gargoylesoftware.htmlunit.html.HtmlDivision;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.User;
+import java.util.Arrays;
+import org.jenkinsci.plugins.ownership.config.DisplayOptions;
+import org.jenkinsci.plugins.ownership.test.util.OwnershipPluginConfigurer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import org.jvnet.hudson.test.Bug;
+
+/**
+ * Tests for {@link RunOwnershipAction}.
+ * @author Oleg Nenashev
+ */
+public class RunOwnershipActionTest {
+    
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+    
+    @Test
+    public void shouldDisplayStubSummaryBoxIfNoOwnership() throws Exception {
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+        
+        assertThat("Run Ownership Box should be enabled in configs", 
+                RunOwnershipHelper.getInstance().isDisplayOwnershipSummaryBox(build), is(true));
+        
+        // Check the Ownership summary box for the Run
+        JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
+        HtmlPage res = webClient.goTo(build.getUrl());
+        HtmlDivision summaryBox = res.<HtmlDivision>getFirstByXPath("//div[@class='ownership-summary-box']");
+        assertThat("On the page there should an ownership box", summaryBox, notNullValue());
+        assertThat("Ownership box should contain no info about the owner", summaryBox.getTextContent(), 
+                stringContainsInOrder(Arrays.asList("Ownership is not configured for this Run")));
+    }
+    
+    @Test
+    public void shouldDisplayRunOwnershipByDefault() throws Exception {
+        
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+        User user = User.get("testUser");
+        
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        JobOwnerHelper.setOwnership(project, new OwnershipDescription(true, user.getId()));
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+        
+        assertThat("Run Ownership Box should be enabled in configs", 
+                RunOwnershipHelper.getInstance().isDisplayOwnershipSummaryBox(build), is(true));
+        
+        // Check the Ownership summary box for the Run
+        JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
+        HtmlPage res = webClient.goTo(build.getUrl());
+        HtmlDivision summaryBox = res.<HtmlDivision>getFirstByXPath("//div[@class='ownership-summary-box']");
+        assertThat("On the page there should an ownership box", summaryBox, notNullValue());
+        HtmlDivision ownerInfo = summaryBox.<HtmlDivision>getFirstByXPath("//div[@class='ownership-user-info']");
+        assertThat("Ownership Summary Box should contain the owner info", summaryBox, notNullValue());
+        assertThat("Owner info should mention user " + user, ownerInfo.getTextContent(), 
+                stringContainsInOrder(Arrays.asList(user.getId())));
+    }
+    
+    @Test
+    @Bug(28714)
+    public void shouldHideRunOwnershipIfRequested() throws Exception {
+        OwnershipPluginConfigurer.forJenkinsRule(jenkinsRule)
+                .withDisplayOptions(new DisplayOptions(true, false))
+                .configure();
+        
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+        
+        assertThat("Run Ownership Box should be disabled in configs", 
+                RunOwnershipHelper.getInstance().isDisplayOwnershipSummaryBox(build), is(false));
+          
+        // Check the Ownership summary box for the Run
+        JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
+        HtmlPage res = webClient.goTo(build.getUrl());
+        assertThat("On the page there should not be ownership box", 
+                res.getFirstByXPath("//div[@class='ownership-summary-box']"), nullValue());
+    }
+    
+    @Test
+    @Bug(28712)
+    public void shouldHideBoxesForNonConfiguredOwnershipIfConfigured() throws Exception {
+        OwnershipPluginConfigurer.forJenkinsRule(jenkinsRule)
+                .withDisplayOptions(new DisplayOptions(false, true))
+                .configure();
+        
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+        
+        assertThat("Run Ownership Box should be disabled in configs", 
+                RunOwnershipHelper.getInstance().isDisplayOwnershipSummaryBox(build), is(false));
+          
+        // Check the Ownership summary box for the Run
+        JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
+        HtmlPage res = webClient.goTo(build.getUrl());
+        assertThat("On the page there should not be ownership box", 
+                res.getFirstByXPath("//div[@class='ownership-summary-box']"), nullValue());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ownership/test/util/OwnershipPluginConfigurer.java
+++ b/src/test/java/org/jenkinsci/plugins/ownership/test/util/OwnershipPluginConfigurer.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ownership.test.util;
+
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPluginConfiguration;
+import com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy;
+import com.synopsys.arc.jenkins.plugins.ownership.extensions.item_ownership_policy.DropOwnershipPolicy;
+import com.synopsys.arc.jenkins.plugins.ownership.security.itemspecific.ItemSpecificSecurity;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.ownership.config.DisplayOptions;
+import org.jenkinsci.plugins.ownership.util.environment.EnvSetupOptions;
+import org.jenkinsci.plugins.ownership.util.mail.MailOptions;
+import org.jvnet.hudson.test.JenkinsRule;
+/**
+ * Manages configuration of {@link OwnershipPlugin}.
+ * @author Oleg Nenashev
+ */
+public class OwnershipPluginConfigurer {
+    
+    private final Jenkins jenkins;
+    
+    // Parameters. All items are nullable
+    private boolean requiresConfigurePermissions;
+    private String mailResolverClassName;
+    private ItemSpecificSecurity defaultJobsSecurity;
+    private ItemOwnershipPolicy itemOwnershipPolicy;
+    private MailOptions mailOptions;
+    private DisplayOptions displayOptions;
+    private EnvSetupOptions globalEnvSetupOptions;
+      
+    private OwnershipPluginConfigurer(Jenkins jenkins) {
+        this.jenkins = jenkins;
+        // Default policy in the plugin
+        this.itemOwnershipPolicy = new DropOwnershipPolicy();
+    }
+    
+    public static OwnershipPluginConfigurer forJenkinsRule(JenkinsRule rule) {
+        return forInstance(rule.jenkins);
+    }
+    
+    public static OwnershipPluginConfigurer forInstance(Jenkins jenkins) {
+        return new OwnershipPluginConfigurer(jenkins);
+    }
+    
+    public OwnershipPluginConfigurer requireConfigurePermissions(boolean requiresConfigurePermissions) {
+        this.requiresConfigurePermissions = requiresConfigurePermissions;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withMailResolverClassName(String mailResolverClassName) {
+        this.mailResolverClassName = mailResolverClassName;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withDefaultJobsSecurity(ItemSpecificSecurity defaultJobsSecurity) {
+        this.defaultJobsSecurity = defaultJobsSecurity;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withItemOwnershipPolicy(@Nonnull ItemOwnershipPolicy itemOwnershipPolicy) {
+        this.itemOwnershipPolicy = itemOwnershipPolicy;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withDisplayOptions(DisplayOptions displayOptions) {
+        this.displayOptions = displayOptions;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withMailOptions(MailOptions mailOptions) {
+        this.mailOptions = mailOptions;
+        return this;
+    }
+    
+    public OwnershipPluginConfigurer withGlobalEnvSetupOptions(EnvSetupOptions globalEnvSetupOptions) {
+        this.globalEnvSetupOptions = globalEnvSetupOptions;
+        return this;
+    }
+    
+    public void configure() throws IOException {
+        OwnershipPluginConfiguration conf = new OwnershipPluginConfiguration
+                (itemOwnershipPolicy, mailOptions, globalEnvSetupOptions, displayOptions);
+        jenkins.getPlugin(OwnershipPlugin.class).configure
+                (requiresConfigurePermissions, mailResolverClassName, defaultJobsSecurity, conf);
+    }
+}


### PR DESCRIPTION
TODO:
- [x] - Display options configuration class
- [x] - JENKINS-28714 - Hide ownership summary boxes for Runs
- [x] - JENKINS-28712 - Do not show empty boxes if ownership is not configured
- [x] - Unit tests