### PR TITLE
[FIXED JENKINS-30254] - Support hiding user-emails in Summary boxes

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
@@ -118,4 +118,14 @@ public class OwnershipPluginConfiguration
         }
     }
     
+    
+    /**
+     * Gets the {@link OwnershipPlugin} configuration.
+     * @return The plugin configuration if available.
+     * @throws IllegalStateException Jenkins instance is not ready
+     * @since 0.8
+     */
+    public static OwnershipPluginConfiguration get() {
+        return OwnershipPlugin.getInstance().getConfiguration();
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
@@ -27,6 +27,7 @@ package com.synopsys.arc.jenkins.plugins.ownership.util.ui;
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.Messages;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPluginConfiguration;
 import com.synopsys.arc.jenkins.plugins.ownership.util.HTMLFormatter;
 import org.jenkinsci.plugins.ownership.util.mail.OwnershipMailHelper;
 import javax.annotation.Nonnull;
@@ -77,10 +78,19 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
 
         @Override
         public String formatUser(TObjectType item, String userId) {
-            final String userURI = HTMLFormatter.formatUserURI(userId, true);
-            final String userEmail = HTMLFormatter.formatEmailURI(userId);
-            final String userInfoHTML = userURI + (userEmail != null ? " " + userEmail : "");
-            return userInfoHTML;
+            StringBuilder rawHtmlBuilder = new StringBuilder();
+            rawHtmlBuilder.append(HTMLFormatter.formatUserURI(userId, true));
+            
+            // Append e-mail to the output if it is not prohibited.
+            if (!OwnershipPluginConfiguration.get().getMailOptions().isHideOwnerAndCoOwnerEmails()) {
+                final String userEmail = HTMLFormatter.formatEmailURI(userId);
+                if (userEmail != null) {
+                    rawHtmlBuilder.append(' ');
+                    rawHtmlBuilder.append(userEmail);
+                }
+            }
+            
+            return rawHtmlBuilder.toString();
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/util/mail/MailOptions.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/util/mail/MailOptions.java
@@ -49,7 +49,8 @@ public class MailOptions implements Describable<MailOptions> {
     
     private final @CheckForNull String emailListSeparator;
     private final @CheckForNull String adminsContactEmail;
-    
+    private final boolean hideOwnerAndCoOwnerEmails;
+
     private static final String DEFAULT_LIST_SEPARATOR = ";";
      
     public static final MailOptions DEFAULT = new MailOptions();
@@ -64,7 +65,8 @@ public class MailOptions implements Describable<MailOptions> {
             boolean contactOwnersLinkDisabled, 
             String contactAdminsSubjectTemplate, String contactAdminsBodyTemplate, 
             boolean contactAdminsLinkDisabled,
-            String adminsContactEmail, String emailListSeparator) {
+            String adminsContactEmail, String emailListSeparator,
+            boolean hideOwnerAndCoOwnerEmails) {
         this.contactOwnersSubjectTemplate = contactOwnersSubjectTemplate;
         this.contactOwnersBodyTemplate = contactOwnersBodyTemplate;
         this.contactOwnersLinkDisabled = contactOwnersLinkDisabled;
@@ -74,7 +76,20 @@ public class MailOptions implements Describable<MailOptions> {
         this.contactAdminsLinkDisabled = contactAdminsLinkDisabled;
         
         this.emailListSeparator = emailListSeparator;
-        this.adminsContactEmail = adminsContactEmail;        
+        this.adminsContactEmail = adminsContactEmail;   
+        this.hideOwnerAndCoOwnerEmails = hideOwnerAndCoOwnerEmails;
+    }
+    
+    @Deprecated
+    public MailOptions(
+            String contactOwnersSubjectTemplate, String contactOwnersBodyTemplate, 
+            boolean contactOwnersLinkDisabled, 
+            String contactAdminsSubjectTemplate, String contactAdminsBodyTemplate, 
+            boolean contactAdminsLinkDisabled,
+            String adminsContactEmail, String emailListSeparator) {
+        this(contactOwnersSubjectTemplate, contactOwnersBodyTemplate, contactOwnersLinkDisabled, 
+             contactAdminsSubjectTemplate, contactAdminsBodyTemplate, contactAdminsLinkDisabled, 
+             adminsContactEmail, emailListSeparator, false);
     }
   
     @Deprecated
@@ -133,6 +148,15 @@ public class MailOptions implements Describable<MailOptions> {
      */
     public boolean isContactOwnersLinkDisabled() {
         return contactOwnersLinkDisabled;
+    }
+
+    /**
+     * Check if displaying e-mails of item owners and co-owners is disabled.
+     * @return {@code} true if the links should not be visualized.
+     * @since 0.8
+     */
+    public boolean isHideOwnerAndCoOwnerEmails() {
+        return hideOwnerAndCoOwnerEmails;
     }
    
     @Extension

--- a/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.jelly
@@ -30,6 +30,10 @@
         <f:textbox/> 
     </f:entry>  
     <f:advanced title="${%Advanced e-mail options}">
+        <f:entry  field="hideOwnerAndCoOwnerEmails">
+            <f:checkbox title="${%hideOwnerAndCoOwnerEmails.title}"/>
+        </f:entry>
+      
         <!-- Contact item owners -->
         <f:entry title="${%contactOwnersSubjectTemplate.title}" field="contactOwnersSubjectTemplate">
             <f:textbox default="${%contactOwnersSubjectTemplate.default}"/> 

--- a/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.properties
@@ -1,3 +1,5 @@
+hideOwnerAndCoOwnerEmails.title=Hide e-mails of owners and co-owners
+
 contactOwnersSubjectTemplate.title=Item Owners Email Subject Template
 contactOwnersBodyTemplate.title=Item Owners Email Subject Template
 contactOwnersLinkDisabled.title=Disable Contact Item Owners link

--- a/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/help-hideOwnerAndCoOwnerEmails.html
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/help-hideOwnerAndCoOwnerEmails.html
@@ -1,0 +1,6 @@
+<div>
+  If checked, disables the visualization of owner and co-owner e-mails in the web interface.
+  <p/>
+  This option may be used to prevent the access to user e-mails by bots if the
+  Jenkins instance is exposed to the Internet.
+</div>


### PR DESCRIPTION
Added an option, which allows to hide user e-mails in ownership summary boxes. This option is disabled by default.

https://issues.jenkins-ci.org/browse/JENKINS-30254

