### PR TITLE
Get rid of "Slaves" in the UI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <groupId>com.synopsys.jenkinsci</groupId>
     <artifactId>ownership</artifactId>
     <version>0.9-SNAPSHOT</version>
-    <name>Job and Slave ownership plugin</name>
+    <name>Job and Node ownership plugin</name>
     <packaging>hpi</packaging>
-    <description>Provides explicit ownership of jobs and slaves</description>
+    <description>Provides explicit ownership of jobs and nodes</description>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Ownership+Plugin</url>
     
     <licenses>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -26,7 +26,7 @@
 -    Parameters:
 -        helper - Helper, which provides info about item
 -        item - Item, which is being described by floating box. Action helper should provide appropriate action helper
--        itemType - name of the item type for visualization (ex, Job or Slave)
+-        itemType - name of the item type for visualization (e.g., Job or Node)
 -        styleClass - class of the div box   
 -
 -    @author Oleg Nenashev

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  Provides explicit support of Jobs and Nodes ownership (property fields, columns, etc.)
+  Provides ownership management engine for Jobs, Nodes and Folders (UI, security integration, etc.)
 </div>

--- a/src/main/webapp/help/primaryOwner.html
+++ b/src/main/webapp/help/primaryOwner.html
@@ -1,10 +1,11 @@
 <div>
-	User, who owns item and has appropriate access rights (ex, maintainer of the job/node).	
+	User, who owns the item and has an appropriate access permissions (ex, maintainer of the job/node).	
 	There're following requirements to the primary owner:
 	<ul>
 		<li>Owner is a registered user</li>
-		<li>Owner should have "Configure" access rights to the job/slave</li>
+		<li>Owner should have "Configure" access rights to the item</li>
 	</ul>
 	
-	During initial setup of the job/slave, ownership will be assigned to the current user. You will be able to change owner after clicking on the "Save" button.
+	During initial setup of the item, ownership will be assigned to the current user. 
+        It is possible to change the owner after clicking the "Save" button.
 </div>


### PR DESCRIPTION
"Slave ownership" is not a good term for Jenkins, especially after Jenkins 2.0 with renaming of slaves to agents.

Also contains minor rewrite of docs nearby.