### PR TITLE
[JENKINS-36946] - Add hint for disabling empty ownership summaries

### DIFF
--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -104,7 +104,12 @@
     <j:if test="${helper.isDisplayOwnershipSummaryBox(item) and !ownershipDescription.ownershipEnabled}">
       <div class="ownership-summary-box">   
         <div class="ownership-header">${itemType} ${%Ownership}</div>
-        <j:out value="${%noOwnership.info.text(itemType)}"/>                
+        <p>
+          ${%noOwnership.info.text(itemType)}
+        </p>
+        <p>
+          <b>${%noOwnership.info.hint}</b> ${%noOwnership.disableDisplayHint.text} <code>${%noOwnership.disableDisplayHint.configPath}</code>
+        </p>
       </div>
     </j:if>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
@@ -4,6 +4,6 @@ adminsMailToLink.text=E-mail to Service owners
 noOwnership.info.hint=HINT:
 noOwnership.info.text=Ownership is not configured for this {0}. \
   It can be configured using the "Manage Ownership" link on the left menu if you have appropriate permissions.
-noOwnership.disableDisplayHint.text=If you to hide this box, you can do it via
+noOwnership.disableDisplayHint.text=If you want to hide this box, you can do it via
 noOwnership.disableDisplayHint.configPath=\
   "Jenkins Global Configuration/Ownership/Ownership Display Options/Hide ownership summaries for missing ownership info"

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
@@ -1,5 +1,9 @@
 ownersMailToLink.text=E-mail to {0} owners
 adminsMailToLink.text=E-mail to Service owners
 
+noOwnership.info.hint=HINT:
 noOwnership.info.text=Ownership is not configured for this {0}. \
   It can be configured using the "Manage Ownership" link on the left menu if you have appropriate permissions.
+noOwnership.disableDisplayHint.text=If you to hide this box, you can do it via
+noOwnership.disableDisplayHint.configPath=\
+  "Jenkins Global Configuration/Ownership/Ownership Display Options/Hide ownership info if there is no data"

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.properties
@@ -6,4 +6,4 @@ noOwnership.info.text=Ownership is not configured for this {0}. \
   It can be configured using the "Manage Ownership" link on the left menu if you have appropriate permissions.
 noOwnership.disableDisplayHint.text=If you to hide this box, you can do it via
 noOwnership.disableDisplayHint.configPath=\
-  "Jenkins Global Configuration/Ownership/Ownership Display Options/Hide ownership info if there is no data"
+  "Jenkins Global Configuration/Ownership/Ownership Display Options/Hide ownership summaries for missing ownership info"

--- a/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/config/DisplayOptions/config.jelly
@@ -28,10 +28,10 @@
     <f:entry title="" description="">
         <table width="100%">
           <f:entry field="hideOwnershipIfNoData">
-            <f:checkbox title="${%Hide ownership info if there is no data}"/>
+            <f:checkbox title="${%Hide ownership summaries for missing ownership info}"/>
           </f:entry>
           <f:entry field="hideRunOwnership">
-            <f:checkbox title="${%Hide ownership info on Run pages}"/>
+            <f:checkbox title="${%Hide ownership summaries on Run pages}"/>
           </f:entry>
         </table>   
     </f:entry> 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-36946

<img width="474" alt="screen shot 2016-07-26 at 12 01 38" src="https://cloud.githubusercontent.com/assets/3000480/17132071/32483890-5331-11e6-8a47-943e4b118622.png">

CC @KostyaSha who requested it at some point