### PR TITLE
Terminology change: rename co-owners to secondary owners

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/IOwnershipHelper.java
@@ -95,7 +95,7 @@ public interface IOwnershipHelper<TObjectType>  {
     public boolean isOwnerExists(@Nonnull TObjectType item);
     
     /**
-     * Get Display string of the owner (and coowners).
+     * Get Display string of the owner.
      * @param item Item to be described
      * @return User description string
      */

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -89,7 +89,7 @@ public class OwnershipDescription implements Serializable {
      * Class is being used as DataBound in {@link OwnerNodeProperty}.
      * @param ownershipEnabled Indicates that the ownership is enabled.
      * @param primaryOwnerId userId of primary owner. Use null if there is no owner 
-     * @param secondaryOwnerIds userIds of secondary owners. Use {@coe null} if there is no secondary owners.
+     * @param secondaryOwnerIds userIds of secondary owners. Use {@code null} if there is no secondary owners.
      */
     public OwnershipDescription(boolean ownershipEnabled, @Nullable String primaryOwnerId, @Nullable Collection<String> secondaryOwnerIds) {
         this.ownershipEnabled = ownershipEnabled;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -42,8 +42,6 @@ import javax.annotation.Nullable;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
-// TODO: cleanup unreleased methods
-
 /**
  * Contains description of item's ownership. 
  * This class is a main information entry for all ownership features.

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -68,7 +68,7 @@ public class OwnershipDescription implements Serializable {
     String primaryOwnerId;
     
     /**
-     * Sids of the co-Owners.
+     * Sids of the secondary owners (fka co-owners).
      * Sids can include users and groups.  
      */
     @Whitelisted
@@ -78,7 +78,7 @@ public class OwnershipDescription implements Serializable {
      * Constructor.
      * @param ownershipEnabled indicates that the ownership is enabled
      * @param primaryOwnerId userId of primary owner
-     * @deprecated Use constructor with co-owners specification
+     * @deprecated Use constructor with secondary owners specification
      */
     public OwnershipDescription(boolean ownershipEnabled, @Nonnull String primaryOwnerId) {
         this(ownershipEnabled, primaryOwnerId, null);
@@ -302,7 +302,7 @@ public class OwnershipDescription implements Serializable {
     /**
      * Gets e-mails of secondary owners.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
-     * @return List of co-owner e-mails (may be empty)
+     * @return List of secondary owner e-mails (may be empty)
      * @since TODO
      * @deprecated use {@link #getSecondaryOwnerEmails()}
      */
@@ -314,7 +314,7 @@ public class OwnershipDescription implements Serializable {
     /**
      * Gets e-mails of secondary owners.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
-     * @return List of co-owner e-mails (may be empty)
+     * @return List of secondary owner e-mails (may be empty)
      * @since TODO
      */
     @Whitelisted

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -42,6 +42,8 @@ import javax.annotation.Nullable;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
+// TODO: cleanup unreleased methods
+
 /**
  * Contains description of item's ownership. 
  * This class is a main information entry for all ownership features.
@@ -87,12 +89,12 @@ public class OwnershipDescription implements Serializable {
      * Class is being used as DataBound in {@link OwnerNodeProperty}.
      * @param ownershipEnabled Indicates that the ownership is enabled.
      * @param primaryOwnerId userId of primary owner. Use null if there is no owner 
-     * @param coownersIds userIds of secondary owners. Use null if there is no co-owners.
+     * @param secondaryOwnerIds userIds of secondary owners. Use {@coe null} if there is no secondary owners.
      */
-    public OwnershipDescription(boolean ownershipEnabled, @Nullable String primaryOwnerId, @Nullable Collection<String> coownersIds) {
+    public OwnershipDescription(boolean ownershipEnabled, @Nullable String primaryOwnerId, @Nullable Collection<String> secondaryOwnerIds) {
         this.ownershipEnabled = ownershipEnabled;
         this.primaryOwnerId = primaryOwnerId;
-        this.coownersIds =  coownersIds != null ? new TreeSet<String>(coownersIds) : new TreeSet<String>();
+        this.coownersIds =  secondaryOwnerIds != null ? new TreeSet<String>(secondaryOwnerIds) : new TreeSet<String>();
     }
     
     public void assign(@Nonnull OwnershipDescription descr) {
@@ -108,10 +110,10 @@ public class OwnershipDescription implements Serializable {
         }
            
         StringBuilder builder = new StringBuilder();
-        builder.append("owner=");
+        builder.append("primary owner=");
         builder.append(primaryOwnerId);
         if (!coownersIds.isEmpty()) {
-            builder.append(" co-owners:[");
+            builder.append(" secondary owners:[");
             for (String coownerId : coownersIds) {
                 builder.append(coownerId);
                 builder.append(' ');
@@ -135,6 +137,7 @@ public class OwnershipDescription implements Serializable {
      * @return userId of the primary owner. The result will be "unknown" if the
      * user is not specified.
      */
+    @Whitelisted
     public @Nonnull String getPrimaryOwnerId() {        
         return ownershipEnabled ? primaryOwnerId :  User.getUnknown().getId();
     }
@@ -150,12 +153,24 @@ public class OwnershipDescription implements Serializable {
     }
 
     /**
-     * Gets list of co-owners.
-     * @return Collection of co-owners
+     * Gets list of secondary owners (fka co-owners).
+     * @return Collection of secondary owners
+     * @deprecated use {@link #getSecondaryOwnerIds()}
+     */
+    @Nonnull
+    @Deprecated
+    public Set<String> getCoownersIds() {
+        return getSecondaryOwnerIds();
+    }
+    
+    /**
+     * Gets list of secondary owners.
+     * @return Collection of secondary owners
+     * @since TODO
      */
     @Nonnull
     @Whitelisted
-    public Set<String> getCoownersIds() {
+    public Set<String> getSecondaryOwnerIds() {
         return coownersIds;
     }
     
@@ -181,21 +196,21 @@ public class OwnershipDescription implements Serializable {
             throws Descriptor.FormException
     {
         // Read primary owner
-        String primaryOwner = formData.getString( "primaryOwner" );
+        String primaryOwnerId = formData.getString( "primaryOwner" );
 
         // Read coowners
-        Set<String> coOwnersSet = new TreeSet<String>();
+        Set<String> secondaryOwnerIds = new TreeSet<String>();
         if (formData.has("coOwners")) {
             JSONObject coOwners = formData.optJSONObject("coOwners");
             if (coOwners == null) {         
                 for (Object obj : formData.getJSONArray("coOwners")) {
-                   addUser(coOwnersSet, (JSONObject)obj);
+                   addUser(secondaryOwnerIds, (JSONObject)obj);
                 }
             } else {
-                addUser(coOwnersSet, coOwners);
+                addUser(secondaryOwnerIds, coOwners);
             }
         }   
-        return new OwnershipDescription(true, primaryOwner, coOwnersSet);
+        return new OwnershipDescription(true, primaryOwnerId, secondaryOwnerIds);
     }
     
     private static void addUser(Set<String> target, JSONObject userObj) throws Descriptor.FormException {
@@ -210,48 +225,66 @@ public class OwnershipDescription implements Serializable {
     /**
      * Check if User is an owner.
      * @param user User to be checked
-     * @param acceptCoowners Check if user belongs to co-owners
-     * @return true if User belongs to primary owners (and/or co-owners)
+     * @param includeSecondaryOwners Check if user belongs to secondary owners
+     * @return {@code true} if the user belongs to primary owners (and/or secondary owners)
      */
-    public boolean isOwner(User user, boolean acceptCoowners) {
+    public boolean isOwner(User user, boolean includeSecondaryOwners) {
         if (user == null) {
             return false;
         }
         if (isPrimaryOwner(user)) {
             return true;
         }
-        return acceptCoowners ? coownersIds.contains(user.getId()) : false;
+        return includeSecondaryOwners ? coownersIds.contains(user.getId()) : false;
     }
     
     @Whitelisted
     public boolean hasPrimaryOwner() {
         return ownershipEnabled && getPrimaryOwner() != null;
     }
-    
-    public boolean isPrimaryOwner(User user) {
+    /**
+     * Checks if the specified user is a primary owner.
+     * @param user User to be checked
+     * @return {@code true} if the user is a primary owner
+     */
+    public boolean isPrimaryOwner(@CheckForNull User user) {
         return user != null && user == getPrimaryOwner();
     }
     
     /**
-     * Gets id of the owner.
+     * Gets ID of the primary owner.
      * @return userId of the primary owner. The result will be "unknown" if the
      * user is not specified.
      * @since TODO
+     * @deprecated Use {@link #getPrimaryOwnerId()}
      */
-    @Whitelisted
+    @Deprecated
     public @Nonnull String getOwnerId() {
         return getPrimaryOwnerId();
     }
     
     /**
-     * Gets owner's e-mail.
+     * Gets primary owner's e-mail.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
-     * @return Owner's e-mail or empty string if it is not available
+     * @return Primary owner's e-mail or empty string if it is not available
+     * @since TODO
+     * @deprecated Use {@link #getPrimaryOwnerEmail()} 
+     */
+    @Nonnull
+    @Deprecated
+    public String getOwnerEmail() {
+        return getPrimaryOwnerEmail();
+    }
+    
+    /**
+     * Gets primary owner's e-mail.
+     * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
+     * @return Primary owner's e-mail or empty string if it is not available
      * @since TODO
      */
     @Nonnull
     @Whitelisted
-    public String getOwnerEmail() {
+    public String getPrimaryOwnerEmail() {
         return OwnershipDescriptionHelper.getOwnerEmail(this);
     }
     
@@ -259,20 +292,33 @@ public class OwnershipDescription implements Serializable {
      * Gets a comma-separated list of co-owners.
      * @return List of co-owner user IDs
      * @since TODO
+     * @deprecated use {@link #getSecondaryOwnerIds()}
      */
-    @Whitelisted
+    @Deprecated
     public @Nonnull Set<String> getCoOwnerIds() {
         return coownersIds;
     }
     
     /**
-     * Gets e-mails of co-owners.
+     * Gets e-mails of secondary owners.
+     * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
+     * @return List of co-owner e-mails (may be empty)
+     * @since TODO
+     * @deprecated use {@link #getSecondaryOwnerEmails()}
+     */
+    @Deprecated
+    public @Nonnull Set<String> getCoOwnerEmails() {
+        return OwnershipDescriptionHelper.getCoOwnerEmailList(this, false);
+    }
+    
+    /**
+     * Gets e-mails of secondary owners.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
      * @return List of co-owner e-mails (may be empty)
      * @since TODO
      */
     @Whitelisted
-    public @Nonnull Set<String> getCoOwnerEmails() {
+    public @Nonnull Set<String> getSecondaryOwnerEmails() {
         return OwnershipDescriptionHelper.getCoOwnerEmailList(this, false);
     }
 
@@ -315,7 +361,7 @@ public class OwnershipDescription implements Serializable {
     
     /**
      * Check if ownership is enabled.
-     * @param descr Ownership description (can be null)
+     * @param descr Ownership description (can be {@code null})
      * @return True if the ownership is enabled
      * @since 0.1
      */

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -306,7 +306,7 @@ public class OwnershipDescription implements Serializable {
      */
     @Deprecated
     public @Nonnull Set<String> getCoOwnerEmails() {
-        return OwnershipDescriptionHelper.getCoOwnerEmailList(this, false);
+        return OwnershipDescriptionHelper.getSecondaryOwnerEmailList(this, false);
     }
     
     /**
@@ -317,7 +317,7 @@ public class OwnershipDescription implements Serializable {
      */
     @Whitelisted
     public @Nonnull Set<String> getSecondaryOwnerEmails() {
-        return OwnershipDescriptionHelper.getCoOwnerEmailList(this, false);
+        return OwnershipDescriptionHelper.getSecondaryOwnerEmailList(this, false);
     }
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -166,7 +166,7 @@ public class OwnershipDescription implements Serializable {
     /**
      * Gets list of secondary owners.
      * @return Collection of secondary owners
-     * @since TODO
+     * @since 0.9
      */
     @Nonnull
     @Whitelisted
@@ -255,7 +255,7 @@ public class OwnershipDescription implements Serializable {
      * Gets ID of the primary owner.
      * @return userId of the primary owner. The result will be "unknown" if the
      * user is not specified.
-     * @since TODO
+     * @since 0.9
      * @deprecated Use {@link #getPrimaryOwnerId()}
      */
     @Deprecated
@@ -267,7 +267,7 @@ public class OwnershipDescription implements Serializable {
      * Gets primary owner's e-mail.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
      * @return Primary owner's e-mail or empty string if it is not available
-     * @since TODO
+     * @since 0.9
      * @deprecated Use {@link #getPrimaryOwnerEmail()} 
      */
     @Nonnull
@@ -280,7 +280,7 @@ public class OwnershipDescription implements Serializable {
      * Gets primary owner's e-mail.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
      * @return Primary owner's e-mail or empty string if it is not available
-     * @since TODO
+     * @since 0.9
      */
     @Nonnull
     @Whitelisted
@@ -291,7 +291,6 @@ public class OwnershipDescription implements Serializable {
     /**
      * Gets a comma-separated list of co-owners.
      * @return List of co-owner user IDs
-     * @since TODO
      * @deprecated use {@link #getSecondaryOwnerIds()}
      */
     @Deprecated
@@ -303,7 +302,6 @@ public class OwnershipDescription implements Serializable {
      * Gets e-mails of secondary owners.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
      * @return List of secondary owner e-mails (may be empty)
-     * @since TODO
      * @deprecated use {@link #getSecondaryOwnerEmails()}
      */
     @Deprecated
@@ -315,7 +313,7 @@ public class OwnershipDescription implements Serializable {
      * Gets e-mails of secondary owners.
      * This method utilizes {@link OwnershipPlugin} global configuration to resolve emails.
      * @return List of secondary owner e-mails (may be empty)
-     * @since TODO
+     * @since 0.9
      */
     @Whitelisted
     public @Nonnull Set<String> getSecondaryOwnerEmails() {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -306,7 +306,7 @@ public class OwnershipDescription implements Serializable {
      */
     @Deprecated
     public @Nonnull Set<String> getCoOwnerEmails() {
-        return OwnershipDescriptionHelper.getSecondaryOwnerEmailList(this, false);
+        return OwnershipDescriptionHelper.getSecondaryOwnerEmails(this, false);
     }
     
     /**
@@ -317,7 +317,7 @@ public class OwnershipDescription implements Serializable {
      */
     @Whitelisted
     public @Nonnull Set<String> getSecondaryOwnerEmails() {
-        return OwnershipDescriptionHelper.getSecondaryOwnerEmailList(this, false);
+        return OwnershipDescriptionHelper.getSecondaryOwnerEmails(this, false);
     }
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
@@ -92,7 +92,6 @@ public class OwnershipJobFilter extends ViewJobFilter {
         this.acceptsCoowners = acceptCoowners;
     }
 
-    //TODO: Bug, filtering of abstract projects only
     @Override
     public List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView) {
         final ArrayList<TopLevelItem> newList = new ArrayList<TopLevelItem>();

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
@@ -45,7 +45,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
- * Filters owner's and co-owners.
+ * Filters jobs by primary and secondary owners.
  * @author Oleg Nenashev
  * @since 0.1
  */
@@ -108,8 +108,8 @@ public class OwnershipJobFilter extends ViewJobFilter {
                 if (userWrapper.meetsMacro(ownership.getPrimaryOwnerId())) {
                     matches = true;
                 }
-                if (acceptsCoowners && !matches) { // Check co-owners
-                    for (String coOwnerId : ownership.getCoownersIds()) {
+                if (acceptsCoowners && !matches) { // Check secondary owners
+                    for (String coOwnerId : ownership.getSecondaryOwnerIds()) {
                         if (userWrapper.meetsMacro(coOwnerId)) {
                             matches = true;
                             break;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -62,7 +63,20 @@ public class OwnershipJobFilter extends ViewJobFilter {
         return ownerId;
     }
 
+    /**
+     * @deprecated use {@link #isAcceptSecondaryOwners()}
+     */
+    @Deprecated
     public boolean isAcceptsCoowners() {
+        return acceptsCoowners;
+    }
+    
+    /**
+     * Enables checking of secondary owners
+     * @return 
+     * @since TODO
+     */
+    public boolean isAcceptSecondaryOwners() {
         return acceptsCoowners;
     }
 
@@ -76,6 +90,7 @@ public class OwnershipJobFilter extends ViewJobFilter {
         this.acceptsCoowners = acceptCoowners;
     }
 
+    //TODO: Bug, filtering of abstract projects only
     @Override
     public List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView) {
         final ArrayList<TopLevelItem> newList = new ArrayList<TopLevelItem>();
@@ -132,6 +147,7 @@ public class OwnershipJobFilter extends ViewJobFilter {
      *
      * @return Collection of all registered users
      */
+    @Nonnull
     public static Collection<UserWrapper> getAvailableUsers() {
         // Sort users
         UserComparator comparator = new UserComparator();

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
@@ -88,7 +88,7 @@ public class OwnersListJobRestriction extends JobRestriction {
     /**
      * Checks if the filter accepts secondary owners.
      * @return {@code true} if secondary owners should be accepted
-     * @since TODO
+     * @since 0.9
      */
     public boolean isAcceptSecondaryOwners() {
         return acceptsCoOwners;

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
@@ -123,8 +123,8 @@ public class OwnersListJobRestriction extends JobRestriction {
                 return true;
             }
 
-            // Handle co-owners if required
-            Set<String> itemCoOwners = descr.getCoownersIds();
+            // Handle secondary owners if required
+            Set<String> itemCoOwners = descr.getSecondaryOwnerIds();
             if (acceptsCoOwners && !itemCoOwners.isEmpty()) {
                 for (String userID : usersMap) {
                     if (itemCoOwners.contains(userID)) {
@@ -134,7 +134,7 @@ public class OwnersListJobRestriction extends JobRestriction {
             }
         }
         
-        // Default fallback - user is not owner or co-owner
+        // Default fallback - user is not a primary or secondary owner
         return false;
     }
 

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction.java
@@ -77,7 +77,20 @@ public class OwnersListJobRestriction extends JobRestriction {
         return usersList;
     }
 
+    /**
+     * @deprecated use {@link #isAcceptSecondaryOwners() } 
+     */
+    @Deprecated
     public boolean isAcceptsCoOwners() {
+        return acceptsCoOwners;
+    }
+    
+    /**
+     * Checks if the filter accepts secondary owners.
+     * @return {@code true} if secondary owners should be accepted
+     * @since TODO
+     */
+    public boolean isAcceptSecondaryOwners() {
         return acceptsCoOwners;
     }
     

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/AbstractOwnershipRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/AbstractOwnershipRoleMacro.java
@@ -49,7 +49,7 @@ import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
  * @author Oleg Nenashev
  * @since 0.1
  */
-abstract class AbstractOwnershipRoleMacro extends RoleMacroExtension {
+public abstract class AbstractOwnershipRoleMacro extends RoleMacroExtension {
     
     public static final String NO_SID_SUFFIX="NoSid";
     protected static final String AUTHENTICATED_SID = "authenticated";

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/AbstractOwnershipRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/AbstractOwnershipRoleMacro.java
@@ -93,11 +93,21 @@ abstract class AbstractOwnershipRoleMacro extends RoleMacroExtension {
         return OwnershipDescription.DISABLED_DESCR;
     }
     
-    public static boolean hasPermission(User user, RoleType type, AccessControlled item, Macro macro, boolean acceptCoowners) {
+    /**
+     * Checks if a user has the permission defined for this macro.
+     * @param user User
+     * @param type Role type
+     * @param item Item, for which permissions are being checked
+     * @param macro Macro expression
+     * @param acceptSecondaryOwners {@code true} if secondary owners should be considered
+     * @return {@code true} if the macro provides a permission.
+     */
+    public static boolean hasPermission(User user, RoleType type, AccessControlled item, 
+            Macro macro, boolean acceptSecondaryOwners) {
         //TODO: implement
         if (user == null) {
             return false;
         }       
-        return getOwnership(type, item).isOwner(user, acceptCoowners);
+        return getOwnership(type, item).isOwner(user, acceptSecondaryOwners);
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacro.java
@@ -37,7 +37,7 @@ import hudson.security.Permission;
  * @author Oleg Nenashev
  * @since 0.2
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -1000)
 public class CoOwnerRoleMacro extends AbstractOwnershipRoleMacro {
     
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacro.java
@@ -33,7 +33,7 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 
 /**
- * Checks if the user belongs to owners or co-owners of the item.
+ * Checks if the user belongs to primary or secondary owners of the item.
  * @author Oleg Nenashev
  * @since 0.2
  */

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacroNoSid.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacroNoSid.java
@@ -33,7 +33,7 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 
 /**
- * Checks if the current user belongs to owners or co-owners of the item (w/o sid control).
+ * Checks if the current user is a primary or secondary owner of the item (w/o sid control).
  * @author Oleg Nenashev
  * @since 0.2
  */

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacroNoSid.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/CoOwnerRoleMacroNoSid.java
@@ -31,13 +31,16 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
+import org.jenkinsci.plugins.ownership.integrations.rolestrategy.macros.CurrentUserIsOwnerMacro;
 
 /**
  * Checks if the current user is a primary or secondary owner of the item (w/o sid control).
  * @author Oleg Nenashev
  * @since 0.2
+ * @deprecated Use {@link CurrentUserIsOwnerMacro}
  */
-@Extension(optional = true)
+@Deprecated
+@Extension(optional = true, ordinal = -1000)
 public class CoOwnerRoleMacroNoSid extends AbstractOwnershipRoleMacro{
     
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/ItemSpecificRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/ItemSpecificRoleMacro.java
@@ -40,7 +40,7 @@ import hudson.security.Permission;
  * @author Oleg Nenashev
  * @since 0.4
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -5)
 public class ItemSpecificRoleMacro extends AbstractOwnershipRoleMacro {
     
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/ItemSpecificRoleMacroWithUserID.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/ItemSpecificRoleMacroWithUserID.java
@@ -36,7 +36,7 @@ import hudson.security.Permission;
  * @author Oleg Nenashev
  * @since 0.4
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -5)
 public class ItemSpecificRoleMacroWithUserID extends ItemSpecificRoleMacro {
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/OwnerRoleMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/rolestrategy/OwnerRoleMacro.java
@@ -36,7 +36,7 @@ import hudson.security.Permission;
  * @author Oleg Nenashev
  * @since 0.2
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -1000)
 public class OwnerRoleMacro extends AbstractOwnershipRoleMacro {
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -110,7 +110,7 @@ public abstract class AbstractOwnershipHelper<TObjectType>
      * @param item Item to be described
      * @return Ownership description. The method returns a 
      * {@link OwnershipDescription#DISABLED_DESCR}
-     * @since TODO
+     * @since 0.9
      */
     @Nonnull
     public abstract OwnershipInfo getOwnershipInfo(@Nonnull TObjectType item);

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
@@ -45,21 +45,49 @@ public class OwnershipDescriptionHelper {
     private OwnershipDescriptionHelper() {}
     
     /**
-     * Gets id of the owner.
+     * Gets ID of the primary owner.
+     * @param descr Ownership description 
+     * @return userId of the primary owner. The result will be "unknown" if the
+     * user is not specified.
+     * @deprecated Use {@link #getPrimaryOwnerId(com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription)}
+     */
+    @Nonnull 
+    @Deprecated
+    public static String getOwnerID(@Nonnull OwnershipDescription descr) {
+        return getPrimaryOwnerId(descr);
+    }
+    
+    /**
+     * Gets id of the primary owner.
      * @param descr Ownership description 
      * @return userId of the primary owner. The result will be "unknown" if the
      * user is not specified.
      */
-    public static @Nonnull String getOwnerID(@Nonnull OwnershipDescription descr) {
+    @Nonnull
+    public static String getPrimaryOwnerId(@Nonnull OwnershipDescription descr) {
         return descr.getPrimaryOwnerId();
     }
     
     /**
      * Gets owner's e-mail.
      * @param descr Ownership description
-     * @return Owner's e-mail or empty string if it is not available 
+     * @return Owner's e-mail or empty string if it is not available
+     * @deprecated Use {@link #getPrimaryOwnerEmail(com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription)}
      */
+    @Nonnull
+    @Deprecated
     public static String getOwnerEmail(@Nonnull OwnershipDescription descr) {
+        return getPrimaryOwnerEmail(descr);
+    }
+    
+    /**
+     * Gets e-mail of the primary owner.
+     * @param descr Ownership description
+     * @return Owner's e-mail or empty string if it is not available
+     * @since 0.9
+     */
+    @Nonnull
+    public static String getPrimaryOwnerEmail(@Nonnull OwnershipDescription descr) {
         String ownerEmail = UserStringFormatter.formatEmail(descr.getPrimaryOwnerId());
         return ownerEmail != null ? ownerEmail : "";
     }
@@ -69,12 +97,13 @@ public class OwnershipDescriptionHelper {
      * @param descr Ownership description
      * @param includeOwner Include owner to the list
      * @return Set of co-owner user IDs
-     * @since TODO
+     * @since 0.9
      */
-    public static @Nonnull Set<String> getCoOwnerIDList(@Nonnull OwnershipDescription descr, boolean includeOwner) {
+    @Nonnull
+    public static Set<String> getSecondaryOwnerIds(@Nonnull OwnershipDescription descr, boolean includeOwner) {
         Set<String> res = new TreeSet<String>();
         if (includeOwner) {
-            res.add(getOwnerID(descr));
+            res.add(getPrimaryOwnerId(descr));
         }
         for (String userId : descr.getSecondaryOwnerIds()) {
             res.add(userId);      
@@ -87,10 +116,31 @@ public class OwnershipDescriptionHelper {
      * Owner will be also considered as co-owner.
      * @param descr Ownership description
      * @return List of co-owner user IDs
+     * @deprecated Use {@link #getAllOwnerIdsString(com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription)}
      */
+    @Deprecated
     public static @Nonnull String getCoOwnerIDs(@Nonnull OwnershipDescription descr) {
         StringBuilder coowners= new StringBuilder();
-        for (String userId : getCoOwnerIDList(descr, true)) {
+        for (String userId : getSecondaryOwnerIds(descr, true)) {
+            //TODO: Bug? Should it be != ?
+            if (coowners.length() == 0) {
+                coowners.append(",");
+            }
+            coowners.append(userId);      
+        }
+        return coowners.toString();
+    }
+    
+    /**
+     * Gets a comma-separated list of primary and secondary owners.
+     * @param descr Ownership description
+     * @return String containing comma-separated list of owner user IDs
+     * @since 0.9
+     */
+    @Nonnull 
+    public static String getAllOwnerIdsString(@Nonnull OwnershipDescription descr) {
+        StringBuilder coowners= new StringBuilder();
+        for (String userId : getSecondaryOwnerIds(descr, true)) {
             //TODO: Bug? Should it be != ?
             if (coowners.length() == 0) {
                 coowners.append(",");
@@ -107,7 +157,7 @@ public class OwnershipDescriptionHelper {
      * @return Set of secondary owner emails
      * @since 0.9
      */
-    public static Set<String> getSecondaryOwnerEmailList(@Nonnull OwnershipDescription descr, boolean includeOwner) {
+    public static Set<String> getSecondaryOwnerEmails(@Nonnull OwnershipDescription descr, boolean includeOwner) {
         Set<String> res = new TreeSet<String>();
         
         if (includeOwner) {
@@ -128,9 +178,9 @@ public class OwnershipDescriptionHelper {
      * @return Comma-separated list of secondary owner e-mails (may be empty)
      * @since 0.9
      */
-    public static String getAllOwnerEmails(@Nonnull OwnershipDescription descr) {
+    public static String getAllOwnerEmailsString(@Nonnull OwnershipDescription descr) {
         StringBuilder coownerEmails=new StringBuilder();
-        for (String coownerEmail : getSecondaryOwnerEmailList(descr, true)) {          
+        for (String coownerEmail : getSecondaryOwnerEmails(descr, true)) {          
             if (coownerEmails.length() != 0) {
                 coownerEmails.append(",");
             }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
@@ -101,13 +101,13 @@ public class OwnershipDescriptionHelper {
     }
     
     /**
-     * Gets e-mails of co-owners (including owner).
+     * Gets e-mails of secondary owners (including owner if required).
      * @param descr Ownership description
      * @param includeOwner Include owner to the list
-     * @return Set of co-owner emails
-     * @since TODO
+     * @return Set of secondary owner emails
+     * @since 0.9
      */
-    public static Set<String> getCoOwnerEmailList(@Nonnull OwnershipDescription descr, boolean includeOwner) {
+    public static Set<String> getSecondaryOwnerEmailList(@Nonnull OwnershipDescription descr, boolean includeOwner) {
         Set<String> res = new TreeSet<String>();
         
         if (includeOwner) {
@@ -123,13 +123,14 @@ public class OwnershipDescriptionHelper {
     }
     
     /**
-     * Gets e-mails of co-owners (including owner).
+     * Gets e-mails of secondary owners (including primary owner).
      * @param descr Ownership description
-     * @return Comma-separated list of co-owner e-mails (may be empty)
+     * @return Comma-separated list of secondary owner e-mails (may be empty)
+     * @since 0.9
      */
-    public static String getCoOwnerEmails(@Nonnull OwnershipDescription descr) {
+    public static String getAllOwnerEmails(@Nonnull OwnershipDescription descr) {
         StringBuilder coownerEmails=new StringBuilder();
-        for (String coownerEmail : getCoOwnerEmailList(descr, true)) {          
+        for (String coownerEmail : getSecondaryOwnerEmailList(descr, true)) {          
             if (coownerEmails.length() != 0) {
                 coownerEmails.append(",");
             }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
@@ -27,13 +27,19 @@ import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+//TODO: Do we really need this helper class now?
+//TODO co-owners have not been renamed to secondary owners, but it's an internal-only class
 /**
  * Provides handlers for ownership description.
  * @author Oleg Nenashev
- * @since 0.4
+ * @since 0.4 - Public API class
+ * @since TODO - Class API is restricted, use OwnershipDescription instead
  * @see OwnershipDescription
  */
+@Restricted(NoExternalUse.class)
 public class OwnershipDescriptionHelper {
     
     private OwnershipDescriptionHelper() {}
@@ -70,7 +76,7 @@ public class OwnershipDescriptionHelper {
         if (includeOwner) {
             res.add(getOwnerID(descr));
         }
-        for (String userId : descr.getCoownersIds()) {
+        for (String userId : descr.getSecondaryOwnerIds()) {
             res.add(userId);      
         }
         return res;
@@ -107,7 +113,7 @@ public class OwnershipDescriptionHelper {
         if (includeOwner) {
             res.add(getOwnerEmail(descr));
         }
-        for (String userId : descr.getCoownersIds()) {          
+        for (String userId : descr.getSecondaryOwnerIds()) {          
             String coownerEmail = UserStringFormatter.formatEmail(userId);
             if (coownerEmail != null) {
                 res.add(coownerEmail);

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
@@ -40,13 +40,48 @@ import javax.annotation.Nonnull;
  */
 public abstract class OwnershipLayoutFormatter<TObjectType> {
     
-    public abstract String formatUser(@Nonnull TObjectType item, String userId);
+    @Nonnull 
+    public abstract String formatUser(@Nonnull TObjectType item, @Nonnull String userId);
     
-    public String formatOwner(@Nonnull TObjectType item, String userId) {
+    /**
+     * Formats primary owner.
+     * @param item Item, for which the formatting is being performed
+     * @param userId User ID
+     * @return Raw HTML with user format
+     * @since TODO
+     */
+    @Nonnull 
+    public String formatPrimaryOwner(@Nonnull TObjectType item, @Nonnull String userId) {
+        return formatOwner(item, userId);
+    }
+    
+    /**
+     * @deprecated Use {@link #formatPrimaryOwner(java.lang.Object, java.lang.String)}
+     */
+    @Deprecated
+    @Nonnull 
+    public String formatOwner(@Nonnull TObjectType item, @Nonnull String userId) {
         return formatUser(item, userId);
     }
     
-    public String formatCoOwner(@Nonnull TObjectType item, String userId) {
+    /**
+     * Formats secondary owner.
+     * @param item Item, for which the formatting is being performed
+     * @param userId User ID
+     * @return Raw HTML with user format
+     * @since TODO
+     */
+    @Nonnull 
+    public String formatSecondaryOwner(@Nonnull TObjectType item, @Nonnull String userId) {
+        return formatCoOwner(item, userId);
+    }
+    
+    /**
+     * @deprecated Use {@link #formatSecondaryOwner(java.lang.Object, java.lang.String)}
+     */
+    @Deprecated
+    @Nonnull 
+    public String formatCoOwner(@Nonnull TObjectType item, @Nonnull String userId) {
         return formatUser(item, userId);
     }
     

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/ui/OwnershipLayoutFormatter.java
@@ -48,7 +48,7 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
      * @param item Item, for which the formatting is being performed
      * @param userId User ID
      * @return Raw HTML with user format
-     * @since TODO
+     * @since 0.9
      */
     @Nonnull 
     public String formatPrimaryOwner(@Nonnull TObjectType item, @Nonnull String userId) {
@@ -69,7 +69,7 @@ public abstract class OwnershipLayoutFormatter<TObjectType> {
      * @param item Item, for which the formatting is being performed
      * @param userId User ID
      * @return Raw HTML with user format
-     * @since TODO
+     * @since 0.9
      */
     @Nonnull 
     public String formatSecondaryOwner(@Nonnull TObjectType item, @Nonnull String userId) {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/wrappers/OwnershipTokenMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/wrappers/OwnershipTokenMacro.java
@@ -124,7 +124,7 @@ public class OwnershipTokenMacro extends DataBoundTokenMacro {
                 case JOB_COOWNERS:
                     return OwnershipDescriptionHelper.getCoOwnerIDs(job);
                 case JOB_COOWNERS_EMAILS:
-                    return OwnershipDescriptionHelper.getCoOwnerEmails(job);   
+                    return OwnershipDescriptionHelper.getAllOwnerEmails(job);   
                 case NODE_OWNER:
                     return OwnershipDescriptionHelper.getOwnerID(node);
                 case NODE_OWNER_EMAIL:
@@ -132,7 +132,7 @@ public class OwnershipTokenMacro extends DataBoundTokenMacro {
                 case NODE_COOWNERS:
                     return OwnershipDescriptionHelper.getCoOwnerIDs(node);
                 case NODE_COOWNERS_EMAILS:
-                    return OwnershipDescriptionHelper.getCoOwnerEmails(node); 
+                    return OwnershipDescriptionHelper.getAllOwnerEmails(node); 
                 default:
                     throw new IOException(this+" ownership function is not implemented");
             }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/wrappers/OwnershipTokenMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/wrappers/OwnershipTokenMacro.java
@@ -83,7 +83,9 @@ public class OwnershipTokenMacro extends DataBoundTokenMacro {
         // Evaluate the macro
         return func.evaluate(job, nodeDescription);
     }
-           
+          
+    // TODO: This implementation needs some polishing in order to address naming changes
+    // in primary and secondary owners
     private static enum OwnershipFunction {
         JOB_OWNER(true),
         JOB_OWNER_EMAIL(true),
@@ -118,21 +120,21 @@ public class OwnershipTokenMacro extends DataBoundTokenMacro {
             
             switch(this) {
                 case JOB_OWNER:
-                    return OwnershipDescriptionHelper.getOwnerID(job);
+                    return OwnershipDescriptionHelper.getPrimaryOwnerId(job);
                 case JOB_OWNER_EMAIL:
-                    return OwnershipDescriptionHelper.getOwnerEmail(job);
+                    return OwnershipDescriptionHelper.getPrimaryOwnerEmail(job);
                 case JOB_COOWNERS:
-                    return OwnershipDescriptionHelper.getCoOwnerIDs(job);
+                    return OwnershipDescriptionHelper.getAllOwnerIdsString(job);
                 case JOB_COOWNERS_EMAILS:
-                    return OwnershipDescriptionHelper.getAllOwnerEmails(job);   
+                    return OwnershipDescriptionHelper.getAllOwnerEmailsString(job);   
                 case NODE_OWNER:
-                    return OwnershipDescriptionHelper.getOwnerID(node);
+                    return OwnershipDescriptionHelper.getPrimaryOwnerId(node);
                 case NODE_OWNER_EMAIL:
-                    return OwnershipDescriptionHelper.getOwnerEmail(node);
+                    return OwnershipDescriptionHelper.getPrimaryOwnerEmail(node);
                 case NODE_COOWNERS:
-                    return OwnershipDescriptionHelper.getCoOwnerIDs(node);
+                    return OwnershipDescriptionHelper.getAllOwnerIdsString(node);
                 case NODE_COOWNERS_EMAILS:
-                    return OwnershipDescriptionHelper.getAllOwnerEmails(node); 
+                    return OwnershipDescriptionHelper.getAllOwnerEmailsString(node); 
                 default:
                     throw new IOException(this+" ownership function is not implemented");
             }

--- a/src/main/java/org/jenkinsci/plugins/ownership/config/InheritanceOptions.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/config/InheritanceOptions.java
@@ -39,7 +39,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * This section is attached as an advanced section to {@link OwnershipPluginConfiguration}.
  * These options has been created 
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class InheritanceOptions implements Describable<InheritanceOptions> {
        

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsOwnerMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsOwnerMacro.java
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy;
+package org.jenkinsci.plugins.ownership.integrations.rolestrategy.macros;
 
-import com.synopsys.arc.jenkins.plugins.ownership.Messages;
+import com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy.AbstractOwnershipRoleMacro;
 import static com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy.AbstractOwnershipRoleMacro.hasPermission;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.Macro;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
@@ -31,31 +31,30 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
-import org.jenkinsci.plugins.ownership.integrations.rolestrategy.macros.CurrentUserIsPrimaryOwnerMacro;
+import org.jenkinsci.plugins.ownership.integrations.rolestrategy.Messages;
 
 /**
- * Provides owner RoleMacro for the role-based strategy (w/o Sid check).
+ * Checks if the current user is an owner.
+ * Primary and secondary owners are fine.
  * @author Oleg Nenashev
- * @since 0.2
- * @deprecated Use {@link CurrentUserIsPrimaryOwnerMacro}
+ * @since 0.9
  */
-@Deprecated
-@Extension(optional = true, ordinal = -1000)
-public class OwnerRoleMacroNoSid extends AbstractOwnershipRoleMacro {
+@Extension(optional = true)
+public class CurrentUserIsOwnerMacro extends AbstractOwnershipRoleMacro {
     
     @Override
     public String getName() {
-        return Messages.Security_RoleStrategy_OwnerRoleMacro_Name()+NO_SID_SUFFIX; 
+        return "CurrentUserIsOwnerMacro"; 
     }
     
     @Override
     public String getDescription() {
-        return Messages.Security_RoleStrategy_OwnerRoleMacro_Description()+Messages.Security_RoleStrategy_IgnoreSidDescriptionSuffix();
+        return Messages.CurrentUserIsOwnerMacro_description();
     }
 
     @Override
     public boolean hasPermission(String sid, Permission p, RoleType type, AccessControlled item, Macro macro) {    
         User user = User.current();              
-        return hasPermission(user, type, item, macro, false);
+        return hasPermission(user, type, item, macro, true);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsOwnerMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsOwnerMacro.java
@@ -44,7 +44,7 @@ public class CurrentUserIsOwnerMacro extends AbstractOwnershipRoleMacro {
     
     @Override
     public String getName() {
-        return "CurrentUserIsOwnerMacro"; 
+        return "CurrentUserIsOwner"; 
     }
     
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsPrimaryOwnerMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsPrimaryOwnerMacro.java
@@ -43,7 +43,7 @@ public class CurrentUserIsPrimaryOwnerMacro extends AbstractOwnershipRoleMacro {
     
     @Override
     public String getName() {
-        return "CurrentUserIsPrimaryOwnerMacro"; 
+        return "CurrentUserIsPrimaryOwner"; 
     }
     
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsPrimaryOwnerMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/rolestrategy/macros/CurrentUserIsPrimaryOwnerMacro.java
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy;
+package org.jenkinsci.plugins.ownership.integrations.rolestrategy.macros;
 
-import com.synopsys.arc.jenkins.plugins.ownership.Messages;
+import com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy.AbstractOwnershipRoleMacro;
 import static com.synopsys.arc.jenkins.plugins.ownership.security.rolestrategy.AbstractOwnershipRoleMacro.hasPermission;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.Macro;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
@@ -31,26 +31,24 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
-import org.jenkinsci.plugins.ownership.integrations.rolestrategy.macros.CurrentUserIsPrimaryOwnerMacro;
+import org.jenkinsci.plugins.ownership.integrations.rolestrategy.Messages;
 
 /**
- * Provides owner RoleMacro for the role-based strategy (w/o Sid check).
+ * Checks if the current user is a primary owner of the item.
  * @author Oleg Nenashev
- * @since 0.2
- * @deprecated Use {@link CurrentUserIsPrimaryOwnerMacro}
+ * @since 0.9
  */
-@Deprecated
-@Extension(optional = true, ordinal = -1000)
-public class OwnerRoleMacroNoSid extends AbstractOwnershipRoleMacro {
+@Extension(optional = true)
+public class CurrentUserIsPrimaryOwnerMacro extends AbstractOwnershipRoleMacro {
     
     @Override
     public String getName() {
-        return Messages.Security_RoleStrategy_OwnerRoleMacro_Name()+NO_SID_SUFFIX; 
+        return "CurrentUserIsPrimaryOwnerMacro"; 
     }
     
     @Override
     public String getDescription() {
-        return Messages.Security_RoleStrategy_OwnerRoleMacro_Description()+Messages.Security_RoleStrategy_IgnoreSidDescriptionSuffix();
+        return Messages.CurrentUserIsPrimaryOwnerMacro_description();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipDescriptionSource.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipDescriptionSource.java
@@ -34,7 +34,7 @@ import javax.annotation.CheckForNull;
  * The summary info can be retrieved using {@code summary.jelly}.
  * @param <TSourceType> Type of the source items.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public abstract class OwnershipDescriptionSource<TSourceType extends Object> {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipHelperLocator.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipHelperLocator.java
@@ -35,7 +35,7 @@ import jenkins.model.Jenkins;
  * Extension point, which allows to identify {@link IOwnershipHelper} for particular classes.
  * @param <T> Type of the item
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public abstract class OwnershipHelperLocator <T extends Object> implements ExtensionPoint {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/OwnershipInfo.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
  * {@link OwnershipDescription} is designed to store the persisted data only,
  * this class also provides a runtime content. It should not be serialized anywhere.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class OwnershipInfo {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction.java
@@ -47,7 +47,7 @@ import org.kohsuke.stapler.StaplerResponse;
 /**
  * Allows managing actions for {@link Folder}s.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class FolderOwnershipAction extends ItemOwnershipAction<AbstractFolder<?>> {
 

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipDescriptionSource.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipDescriptionSource.java
@@ -31,7 +31,7 @@ import org.jenkinsci.plugins.ownership.model.OwnershipDescriptionSource;
 /**
  * References {@link OwnershipDescription}s provided by various {@link AbstractFolder}s.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class FolderOwnershipDescriptionSource extends OwnershipDescriptionSource<AbstractFolder<?>> {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
@@ -52,7 +52,7 @@ import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 /**
  * Integration with Folders plugin.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class FolderOwnershipHelper extends AbstractOwnershipHelper<AbstractFolder<?>> {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipProperty.java
@@ -41,7 +41,7 @@ import org.kohsuke.stapler.StaplerRequest;
 /**
  * Ownership property for {@link Folder}s.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class FolderOwnershipProperty 
         extends AbstractFolderProperty<AbstractFolder<?>> 

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/jobs/JobOwnershipDescriptionSource.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/jobs/JobOwnershipDescriptionSource.java
@@ -31,7 +31,7 @@ import org.jenkinsci.plugins.ownership.model.OwnershipDescriptionSource;
 /**
  * References {@link OwnershipDescription}s provided by various {@link Job}s.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class JobOwnershipDescriptionSource extends OwnershipDescriptionSource<Job<?,?>> {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/nodes/NodeOwnershipDescriptionSource.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/nodes/NodeOwnershipDescriptionSource.java
@@ -30,7 +30,7 @@ import org.jenkinsci.plugins.ownership.model.OwnershipDescriptionSource;
 /**
  * References {@link OwnershipDescription}s provided by various {@link Node}s.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 public class NodeOwnershipDescriptionSource extends OwnershipDescriptionSource<Node> {
     

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable.java
@@ -48,7 +48,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Provides {@link OwnershipDescription}s for different item types.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 0.9
  */
 @Extension
 public class OwnershipGlobalVariable extends GlobalVariable {

--- a/src/main/java/org/jenkinsci/plugins/ownership/util/mail/MailOptions.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/util/mail/MailOptions.java
@@ -151,7 +151,7 @@ public class MailOptions implements Describable<MailOptions> {
     }
 
     /**
-     * Check if displaying e-mails of item owners and co-owners is disabled.
+     * Check if displaying e-mails of item owners is disabled.
      * @return {@code} true if the links should not be visualized.
      * @since 0.8
      */

--- a/src/main/java/org/jenkinsci/plugins/ownership/util/mail/OwnershipMailHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/util/mail/OwnershipMailHelper.java
@@ -121,8 +121,8 @@ public class OwnershipMailHelper {
             }
         }
 
-        // cc - job co-owners
-        final Set<String> coOwners = ownershipDescription.getCoownersIds();
+        // cc - job secondary owners
+        final Set<String> coOwners = ownershipDescription.getSecondaryOwnerIds();
         if (!coOwners.isEmpty()) {
             for (String coOwnerId : coOwners) {
                 String email = UserStringFormatter.formatEmail(coOwnerId);

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/ItemOwnershipAction/propertyConfig.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/ItemOwnershipAction/propertyConfig.jelly
@@ -59,11 +59,11 @@
         </select> 
 
     </f:entry>
-    <f:entry title="Co-owners" help="/plugin/ownership/help/coOwner.html"/>
+    <f:entry title="${%Secondary owners}" help="/plugin/ownership/help/coOwner.html"/>
     <f:entry>
-        <f:repeatable name="coOwners" add="${%Add co-owner}" var="_coownerId" items="${it.helper().getOwnershipDescription(_item).getCoownersIds()}">                                    
+        <f:repeatable name="coOwners" add="${%Add secondary owner}" var="_coownerId" items="${it.helper().getOwnershipDescription(_item).getCoownersIds()}">                                    
             <table width="100%">
-                <f:entry title="Co-owner">
+                <f:entry title="Secondary owner">
                     <f:textbox field="coOwner" value="${_coownerId}"
                                checkUrl="'${rootURL}/plugin/ownership/checkUser?userId='+this.value"
                     />

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -15,13 +15,13 @@ NodeOwnership.Monitor.DisplayName=Ownership
 NodesOwnership.Config.SectionTitle=Node ownership
 
 Security.RoleStrategy.OwnerRoleMacro.Name=Owner
-Security.RoleStrategy.OwnerRoleMacro.Description=Checks if the user is an item&rsquo;s owner.
+Security.RoleStrategy.OwnerRoleMacro.Description=<strong>Deprecated</strong>. Checks if the user is an item&rsquo;s owner.
 Security.RoleStrategy.CoOwnerRoleMacro.Name=CoOwner
-Security.RoleStrategy.CoOwnerRoleMacro.Description=Checks if the current user is an item&rsquo;s primary or secondary owner.
+Security.RoleStrategy.CoOwnerRoleMacro.Description=<strong>Deprecated</strong>. Checks if the current user is an item&rsquo;s primary or secondary owner.
 Security.RoleStrategy.IgnoreSidDescriptionSuffix=<p style="color:red">Warning! User SID will be replaced by the current user</p>
 Security.RoleStrategy.WithUserDescriptionSuffix=In addition to SIDs, macro checks ID of the current user during evaluation of &quotauthenticated&quot SID.  
 Security.RoleStrategy.NoOwnerRoleMacro.Name=NoOwner
-Security.RoleStrategy.NoOwnerRoleMacro.Description=Checks if the item has not ownership.
+Security.RoleStrategy.NoOwnerRoleMacro.Description=Checks if the item has no ownership specified.
 Security.RoleStrategy.ItemSpecificMacro.Name=ItemSpecific
 Security.RoleStrategy.ItemSpecificMacro.Description=Invokes evaluation of item-specific access rights.
 Security.JobRestrictions.OwnershipRestriction.DisplayName=Job's owners belong to the list

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -7,7 +7,7 @@ OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
 
 
 JobOwnership.Config.SectionTitle=Job ownership
-JobOwnership.Column.Title=Job Owner
+JobOwnership.Column.Title=Primary Owner
 JobOwnership.Filter.DisplayName=Ownership Filter
 
 NodeOwnership.Config.SectionTitle=Node ownership

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/Messages.properties
@@ -1,7 +1,7 @@
 # Ownership plugin
 OwnershipPlugin.ManagePermissions.Title=Manage ownership
-OwnershipPlugin.ManagePermissions.SlaveDescription=Manage node ownership(set owners and co-owners)
-OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership(set owners and co-owners)
+OwnershipPlugin.ManagePermissions.SlaveDescription=Manage node ownership (set primary and secondary owners)
+OwnershipPlugin.ManagePermissions.JobDescription=Manage jobs ownership (set primary and secondary owners)
 
 OwnershipPlugin.FloatingBox.ContactOwners.Title=Contact Owners
 
@@ -17,7 +17,7 @@ NodesOwnership.Config.SectionTitle=Node ownership
 Security.RoleStrategy.OwnerRoleMacro.Name=Owner
 Security.RoleStrategy.OwnerRoleMacro.Description=Checks if the user is an item&rsquo;s owner.
 Security.RoleStrategy.CoOwnerRoleMacro.Name=CoOwner
-Security.RoleStrategy.CoOwnerRoleMacro.Description=Checks if the current user belongs to item&rsquo;s owners or co-owners.
+Security.RoleStrategy.CoOwnerRoleMacro.Description=Checks if the current user is an item&rsquo;s primary or secondary owner.
 Security.RoleStrategy.IgnoreSidDescriptionSuffix=<p style="color:red">Warning! User SID will be replaced by the current user</p>
 Security.RoleStrategy.WithUserDescriptionSuffix=In addition to SIDs, macro checks ID of the current user during evaluation of &quotauthenticated&quot SID.  
 Security.RoleStrategy.NoOwnerRoleMacro.Name=NoOwner

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -43,11 +43,11 @@
     <!-- Layout for ownership with available data -->
     <j:if test="${helper.isDisplayOwnershipSummaryBox(item) and ownershipDescription.ownershipEnabled}">
       <div class="ownership-summary-box">   
-        <div class="ownership-header">${itemType} ${%Ownership}</div>            
+        <div class="ownership-header">${itemType} ${%Owners}</div>            
         <table>
             <tr>
                 <td>
-                    <div class="ownership-section">${%Owner}</div>
+                    <div class="ownership-section">${%Primary}</div>
                 </td>
                 <td>
                     <div class="ownership-user-info">
@@ -56,12 +56,12 @@
                 </td>
             </tr>
         
-            <!-- Co-owners -->    
+            <!-- Secondary owners (fka Co-owners) -->    
             <j:set var="coownersList" value="${helper.getOwnershipDescription(item).getCoownersIds()}"/>
             <j:if test="${not coownersList.isEmpty()}">
                 <tr>
                     <td>        
-                        <div class="ownership-section">${%Co-owners}</div>
+                        <div class="ownership-section">${%Secondary}</div>
                     </td>       
                     <td>
                         <j:forEach var="coownerId" items="${coownersList}">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerColumn/columnHeader.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerColumn/columnHeader.jelly
@@ -24,6 +24,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <th>
-    ${%Owner}
+    ${%Primary Owner}
   </th>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerColumn/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerColumn/config.jelly
@@ -26,6 +26,6 @@
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <f:block>
-        <p>${%This column shows owner of the job.}</p>
+        <p>${%This column shows the primary owner of the job.}</p>
     </f:block>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/index.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/index.jelly
@@ -48,7 +48,7 @@
 
             <table style="padding-left: 2em;" id="management-links">
               <local:feature icon="user.gif" href="manage-owners" title="${it.manageOwnershipTitle}">
-                ${%Manage Owners, add co-owners, etc.}
+                ${%Manage primary and secondary owners}
               </local:feature>
               <local:feature icon="fingerprint.gif" href="configure-project-specifics" title="${it.configureSpecificAccessTitle}">
                 ${%Configure job-specific access rights}.

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/OwnershipJobFilter/config.jelly
@@ -36,6 +36,6 @@
     </f:entry> 
     <f:description>Filter will check ownership of the specified user</f:description>
     <f:entry help="/plugin/ownership/help/filter_acceptCoowners.html">
-        <f:checkbox name="acceptsCoowners" field="acceptsCoowners"/> ${%Accept co-owned jobs}
+        <f:checkbox name="acceptsCoowners" field="acceptsCoowners"/> ${%Accept items, where the user is a secondary owner}
     </f:entry> 
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/index.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/index.jelly
@@ -48,7 +48,7 @@
 
             <table style="padding-left: 2em;" id="management-links">
               <local:feature icon="user.gif" href="manage-owners" title="${it.manageOwnershipTitle}">
-                ${%Manage Owners, add co-owners, etc.}
+                ${%Manage primary and secondary owners}
               </local:feature>
               <!--Disabled in 0.3-->
              <!-- <local:feature icon="fingerprint.gif" href="configure-project-specifics" title="${it.configureSpecificAccessTitle}">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/config.jelly
@@ -25,7 +25,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry field="acceptsCoOwners" title="${%Secondary owners}">
+    <f:entry field="acceptsCoOwners" title="${%Secondary}">
         <f:checkbox title="${%Accept job secondary owners}" checked="${it.acceptsCoOwners}"/>
     </f:entry>
     <f:entry title="${%Users list}"> 

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/config.jelly
@@ -25,8 +25,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry field="acceptsCoOwners" title="${%Co-owners}">
-        <f:checkbox title="${%Accept job co-owners}" checked="${it.acceptsCoOwners}"/>
+    <f:entry field="acceptsCoOwners" title="${%Secondary owners}">
+        <f:checkbox title="${%Accept job secondary owners}" checked="${it.acceptsCoOwners}"/>
     </f:entry>
     <f:entry title="${%Users list}"> 
         <f:repeatableProperty field="usersList" add="${%Add owner}"/>  

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/help-acceptsCoOwners.html
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/security/jobrestrictions/OwnersListJobRestriction/help-acceptsCoOwners.html
@@ -1,4 +1,4 @@
 <div>
-    If checked, job will be accepted if one of the listed users is owner or co-owner of the job.
-    By default, only owners will be accepted.
+    If checked, job will be accepted if one of the listed users is a primary or secondary owner of the job.
+    By default, only primary owners will be accepted.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/integrations/rolestrategy/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/integrations/rolestrategy/Messages.properties
@@ -1,0 +1,3 @@
+CurrentUserIsOwnerMacro.description= Checks if the current user is an owner of the item (both primary and secondary work)
+CurrentUserIsPrimaryOwnerMacro.description= Checks if the current user is a primary owner of the item
+

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction/index.jelly
@@ -48,7 +48,7 @@
 
             <table style="padding-left: 2em;" id="management-links">
               <local:feature icon="user.gif" href="manage-owners" title="${it.manageOwnershipTitle}">
-                ${%Manage Owners, add co-owners, etc.}
+                ${%Manage primary and secondary owners}
               </local:feature>              
             </table>
         </l:main-panel>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
@@ -52,12 +52,12 @@
     Usage example:
    
     stage 'Print Job Ownership Info';
-    def ownerEmail = ownership.job.ownerEmail
+    def ownerEmail = ownership.job.primaryOwnerEmail
     if (ownership.job.ownershipEnabled) {
-      println "Owner ID: ${ownership.job.ownerId}"
+      println "Owner ID: ${ownership.job.primaryOwnerId}"
       println "Owner e-mail: ${ownerEmail}"
-      println "Co-owner IDs: ${ownership.job.coOwnerIds}"
-      println "Co-owner e-mails: ${ownership.job.coOwnerEmails}"
+      println "Co-owner IDs: ${ownership.job.secondaryOwnerIds}"
+      println "Co-owner e-mails: ${ownership.job.secondaryOwnerEmails}"
     } else {
       println "Ownership is disabled";
     }

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
@@ -25,25 +25,25 @@
      Type: <code>boolean</code>.
    </dd>
    
-   <dt>ownerId</dt>
+   <dt>primaryOwnerId</dt>
    <dd>
-     User ID of the item owner. 
+     User ID of the primary owner. 
      Type: <code>java.lang.String</code>.
    </dd>
    
-   <dt>ownerEmail</dt>
+   <dt>primaryOwnerEmail</dt>
    <dd>
-     Email of the item owner. Type: <code>java.lang.String</code>.
+     Email of the primary owner. Type: <code>java.lang.String</code>.
    </dd>
    
-   <dt>coOwnerIds</dt>
+   <dt>secondaryOwnerIds</dt>
    <dd>
-     Collection of the item co-owner user IDs (does not include the item owner). 
+     Collection of the item secondary owner user IDs (does not include the item owner). 
      Type: <code>java.util.Set&lt;String&gt;</code>.
    </dd>
    
-   <dt>coOwnerEmails</dt>
-   <dd>Collection of the item co-owner e-mails (does not include the item owner). 
+   <dt>secondaryOwnerEmails</dt>
+   <dd>Collection of the secondary owner e-mails (does not include the item owner). 
      Type: <code>java.util.Set&lt;String&gt;</code>.
    </dd>
  </dl>
@@ -52,10 +52,10 @@
     Usage example:
    
     stage 'Print Job Ownership Info';
-    def ownerEmail = ownership.job.primaryOwnerEmail
+    def primaryOwnerEmail = ownership.job.primaryOwnerEmail
     if (ownership.job.ownershipEnabled) {
       println "Owner ID: ${ownership.job.primaryOwnerId}"
-      println "Owner e-mail: ${ownerEmail}"
+      println "Owner e-mail: ${primaryOwnerEmail}"
       println "Co-owner IDs: ${ownership.job.secondaryOwnerIds}"
       println "Co-owner e-mails: ${ownership.job.secondaryOwnerEmails}"
     } else {
@@ -63,7 +63,7 @@
     }
     
     stage 'Send e-mail to the job owner'
-    mail to: ownerEmail,
+    mail to: primaryOwnerEmail,
       subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
       body: "Please go to ${env.BUILD_URL} and verify the build"
   </pre>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/help.jelly
@@ -1,4 +1,6 @@
 <?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <div>
  Provides ownership info for different item types.
  <p/>
@@ -48,23 +50,15 @@
    </dd>
  </dl>
  
+ <j:invokeStatic method="getSampleSnippet" 
+                 className="org.jenkinsci.plugins.ownership.model.workflow.OwnershipGlobalVariable" 
+                 var="snippetCode">
+   <j:arg value="forHelp"/>
+ </j:invokeStatic>
+ 
+ Usage example:
  <pre>
-    Usage example:
-   
-    stage 'Print Job Ownership Info';
-    def primaryOwnerEmail = ownership.job.primaryOwnerEmail
-    if (ownership.job.ownershipEnabled) {
-      println "Owner ID: ${ownership.job.primaryOwnerId}"
-      println "Owner e-mail: ${primaryOwnerEmail}"
-      println "Co-owner IDs: ${ownership.job.secondaryOwnerIds}"
-      println "Co-owner e-mails: ${ownership.job.secondaryOwnerEmails}"
-    } else {
-      println "Ownership is disabled";
-    }
-    
-    stage 'Send e-mail to the job owner'
-    mail to: primaryOwnerEmail,
-      subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
-      body: "Please go to ${env.BUILD_URL} and verify the build"
-  </pre>
+    ${snippetCode}
+ </pre>
 </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_forHelp.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_forHelp.groovy
@@ -1,0 +1,15 @@
+stage 'Print Job Ownership Info';
+def primaryOwnerEmail = ownership.job.primaryOwnerEmail
+if (ownership.job.ownershipEnabled) {
+  println "Primary owner ID: ${ownership.job.primaryOwnerId}"
+  println "Primary owner e-mail: ${primaryOwnerEmail}"
+  println "Secondary owner IDs: ${ownership.job.secondaryOwnerIds}"
+  println "Secondary owner e-mails: ${ownership.job.secondaryOwnerEmails}"
+} else {
+  println "Ownership is disabled";
+}
+
+stage 'Send e-mail to the job owner'
+mail to: primaryOwnerEmail,
+  subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
+  body: "Please go to ${env.BUILD_URL} and verify the build"

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_printJobOwnershipInfo.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_printJobOwnershipInfo.groovy
@@ -1,9 +1,9 @@
 stage 'Print Job Ownership Info';
 if (ownership.job.ownershipEnabled) {
-  println "Owner ID: ${ownership.job.ownerId}"
-  println "Owner e-mail: ${ownership.job.ownerEmail}"
-  println "Co-owner IDs: ${ownership.job.coOwnerIds}"
-  println "Co-owner e-mails: ${ownership.job.coOwnerEmails}"
+  println "Owner ID: ${ownership.job.primaryOwnerId}"
+  println "Owner e-mail: ${ownership.job.primaryOwnerEmail}"
+  println "Co-owner IDs: ${ownership.job.secondaryOwnerIds}"
+  println "Co-owner e-mails: ${ownership.job.secondaryOwnerEmails}"
 } else {
   println "Ownership is disabled";
 }

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_printNodeOwnershipInfo.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/workflow/OwnershipGlobalVariable/sample_printNodeOwnershipInfo.groovy
@@ -2,10 +2,10 @@ stage 'Print Node Ownership Info'
 node('requiredLabel') {
   echo "Current NODE_NAME = ${env.NODE_NAME}";
   if (ownership.node.ownershipEnabled) {
-    println "Owner ID: ${ownership.node.ownerId}"
-    println "Owner e-mail: ${ownership.node.ownerEmail}"
-    println "Co-owner IDs: ${ownership.node.coOwnerIds}"
-    println "Co-owner e-mails: ${ownership.node.coOwnerEmails}"
+    println "Owner ID: ${ownership.node.primaryOwnerId}"
+    println "Owner e-mail: ${ownership.node.primaryOwnerEmail}"
+    println "Co-owner IDs: ${ownership.node.secondaryOwnerIds}"
+    println "Co-owner e-mails: ${ownership.node.secondaryOwnerEmails}"
   } else {
     println "Ownership of ${env.NODE_NAME} is disabled";
   }

--- a/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/config.properties
@@ -1,4 +1,4 @@
-hideOwnerAndCoOwnerEmails.title=Hide e-mails of owners and co-owners
+hideOwnerAndCoOwnerEmails.title=Hide e-mails of owners
 
 contactOwnersSubjectTemplate.title=Item Owners Email Subject Template
 contactOwnersBodyTemplate.title=Item Owners Email Subject Template

--- a/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/help-hideOwnerAndCoOwnerEmails.html
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/util/mail/MailOptions/help-hideOwnerAndCoOwnerEmails.html
@@ -1,5 +1,5 @@
 <div>
-  If checked, disables the visualization of owner and co-owner e-mails in the web interface.
+  If checked, disables the visualization of primary and secondary owner e-mails in the web interface.
   <p/>
   This option may be used to prevent the access to user e-mails by bots if the
   Jenkins instance is exposed to the Internet.

--- a/src/main/webapp/help/coOwner.html
+++ b/src/main/webapp/help/coOwner.html
@@ -1,4 +1,5 @@
 <div>
-Additional users, who have ownership privileges (ex, backup of primary owner).
-Plugin allows to set non-registered users as a co-owners.
+Additional users, who have ownership privileges.
+Plugin allows assigning non-registered users as a secondary owners,
+but they will need to login in order to make the ownership effective in the entire Ownership plugin logic.
 </div>


### PR DESCRIPTION
The idea is to pick low-hanging fruits like classes for Pipeline integration and APIs.
Generally it's not realistic to change everything (enum values, etc.)

Changes:
* "owner" => "primary owner"
* "co-Owner" => "secondary owner"

TODO:
- [x] Base classes - change API to secondaryOwners where it is possible
- [x] Ownership management UIs
- [x] Pipeline documentation and samples
- [x] Ownership variables injection - variable names and documentation
- [x] Role strategy macros
- POSTPONED: Injected environment variables

Change examples:

<img width="469" alt="screen shot 2016-09-15 at 03 41 26" src="https://cloud.githubusercontent.com/assets/3000480/18547085/6a328b6a-7af6-11e6-9606-2203287cb8bb.png">
<img width="522" alt="screen shot 2016-09-15 at 03 41 54" src="https://cloud.githubusercontent.com/assets/3000480/18547086/6a33ae28-7af6-11e6-8648-3e7b6aca8669.png">
<img width="582" alt="screen shot 2016-09-15 at 03 42 07" src="https://cloud.githubusercontent.com/assets/3000480/18547084/6a31fbaa-7af6-11e6-89b0-0911e6db2e0e.png">

