### PR TITLE
[FIXED JENKINS-38238] - Properly handle user lists for build wrappers

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/OwnershipDescriptionHelper.java
@@ -119,16 +119,9 @@ public class OwnershipDescriptionHelper {
      * @deprecated Use {@link #getAllOwnerIdsString(com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription)}
      */
     @Deprecated
-    public static @Nonnull String getCoOwnerIDs(@Nonnull OwnershipDescription descr) {
-        StringBuilder coowners= new StringBuilder();
-        for (String userId : getSecondaryOwnerIds(descr, true)) {
-            //TODO: Bug? Should it be != ?
-            if (coowners.length() == 0) {
-                coowners.append(",");
-            }
-            coowners.append(userId);      
-        }
-        return coowners.toString();
+    @Nonnull
+    public static String getCoOwnerIDs(@Nonnull OwnershipDescription descr) {
+        return getAllOwnerEmailsString(descr);
     }
     
     /**
@@ -141,8 +134,7 @@ public class OwnershipDescriptionHelper {
     public static String getAllOwnerIdsString(@Nonnull OwnershipDescription descr) {
         StringBuilder coowners= new StringBuilder();
         for (String userId : getSecondaryOwnerIds(descr, true)) {
-            //TODO: Bug? Should it be != ?
-            if (coowners.length() == 0) {
+            if (coowners.length() != 0) {
                 coowners.append(",");
             }
             coowners.append(userId);      


### PR DESCRIPTION
The change prevents the broken item separation in the list.

https://issues.jenkins-ci.org/browse/JENKINS-38238