### PR TITLE
[JENKINS38236,JENKINS-38235] - Prevent issues during ItemPolicy handling

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPluginConfiguration.java
@@ -25,6 +25,7 @@
 package com.synopsys.arc.jenkins.plugins.ownership;
 
 import com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy;
+import com.synopsys.arc.jenkins.plugins.ownership.extensions.item_ownership_policy.DropOwnershipPolicy;
 import org.jenkinsci.plugins.ownership.util.mail.MailOptions;
 import hudson.Extension;
 import hudson.model.Describable;
@@ -87,7 +88,7 @@ public class OwnershipPluginConfiguration
     }
 
     public @Nonnull ItemOwnershipPolicy getItemOwnershipPolicy() {
-        return itemOwnershipPolicy;
+        return itemOwnershipPolicy != null ? itemOwnershipPolicy : ItemOwnershipPolicy.getDefault();
     }
 
     public @Nonnull MailOptions getMailOptions() {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/ItemOwnershipPolicy.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/ItemOwnershipPolicy.java
@@ -83,7 +83,7 @@ public abstract class ItemOwnershipPolicy
     @Override
     public ItemOwnershipPolicyDescriptor getDescriptor() {
         return (ItemOwnershipPolicyDescriptor) Jenkins.getActiveInstance()
-                .getDescriptorOrDie(ItemOwnershipPolicy.class);
+                .getDescriptorOrDie(getClass());
     }
     
     /**

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/ItemOwnershipPolicy.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/extensions/ItemOwnershipPolicy.java
@@ -25,6 +25,7 @@
 package com.synopsys.arc.jenkins.plugins.ownership.extensions;
 
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.extensions.item_ownership_policy.DropOwnershipPolicy;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
@@ -33,6 +34,8 @@ import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Implements an ownership changes policy for {@link Item}s. 
@@ -41,6 +44,18 @@ import jenkins.model.Jenkins;
  */
 public abstract class ItemOwnershipPolicy 
         implements ExtensionPoint, Describable<ItemOwnershipPolicy> {
+    
+    private static final ItemOwnershipPolicy DEFAULT = new DropOwnershipPolicy();
+    
+    /**
+     * Returns default Item Ownership Policy, which should be assigned on first startup.
+     * @return Ownership policy
+     */
+    @Nonnull
+    @Restricted(NoExternalUse.class)
+    public static ItemOwnershipPolicy getDefault() {
+        return DEFAULT;
+    }
     
     /**
      * A handler for newly created items.


### PR DESCRIPTION
- [x] Proper descriptor definition for ItemOwnershipPolicy implementations  [JENKINS-38235](https://issues.jenkins-ci.org/browse/JENKINS-38235)
- [x] Make the plugin robust against null ItemOwnershipPolicy [JENKINS-38236](https://issues.jenkins-ci.org/browse/JENKINS-38236)