### PR TITLE
[JENKINS-32353] - Update Authorize Project integration to a Pipeline-compatible version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>authorize-project</artifactId>
-            <version>1.0.2</version>
+            <version>1.1.0</version>
             <optional>true</optional>
             <type>jar</type>
         </dependency>

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/authorizeproject/OwnershipAuthorizeProjectStrategy.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/security/authorizeproject/OwnershipAuthorizeProjectStrategy.java
@@ -29,6 +29,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
 import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.User;
 import java.util.Collections;
@@ -53,8 +54,8 @@ public class OwnershipAuthorizeProjectStrategy extends AuthorizeProjectStrategy 
     }
 
     @Override
-    public Authentication authenticate(AbstractProject<?, ?> ap, Queue.Item item) {    
-        OwnershipDescription d = JobOwnerHelper.Instance.getOwnershipDescription(ap);
+    public Authentication authenticate(Job<?, ?> job, Queue.Item item) {    
+        OwnershipDescription d = JobOwnerHelper.Instance.getOwnershipDescription(job);
         if (!d.hasPrimaryOwner()) { // fallback to anonymous
             return Jenkins.ANONYMOUS;
         }    


### PR DESCRIPTION
Ideally the core dependency should be updated to 1.625