### PR TITLE
[JENKINS-38353] - Fix handling of Computed folders

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
@@ -28,6 +28,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy;
 import hudson.Extension;
+import hudson.Plugin;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
 import java.io.IOException;
@@ -67,7 +68,8 @@ public class FolderItemListener extends ItemListener {
     }
     
     private boolean isFoldersPluginEnabled() {
-        return Jenkins.getActiveInstance().getPlugin("cloudbees-folder") != null;
+        final Plugin plugin = Jenkins.getActiveInstance().getPlugin("cloudbees-folder");
+        return plugin != null && plugin.getWrapper().isActive();
     }
     
     private void modifyOwnership(Item item, OwnershipDescription ownership) {

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
@@ -33,6 +33,7 @@ import hudson.model.listeners.ItemListener;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 /**
  * Locates changes in {@link AbstractFolder}s and assigns ownership accordingly.
@@ -44,19 +45,29 @@ public class FolderItemListener extends ItemListener {
     private static final Logger LOGGER = Logger.getLogger(FolderItemListener.class.getName());
     
     @Override
-    public void onCopied(Item src, Item item) {      
+    public void onCopied(Item src, Item item) {     
+        if (!isFoldersPluginEnabled()) {
+            return;
+        }
         OwnershipDescription d = getPolicy().onCopied(src, item);
         modifyOwnership(item, d);
     }
 
     @Override
     public void onCreated(Item item) {
+        if (!isFoldersPluginEnabled()) {
+            return;
+        }
         OwnershipDescription d = getPolicy().onCreated(item);
         modifyOwnership(item, d);
     }
     
     private ItemOwnershipPolicy getPolicy() {
         return OwnershipPlugin.getInstance().getConfiguration().getItemOwnershipPolicy();
+    }
+    
+    private boolean isFoldersPluginEnabled() {
+        return Jenkins.getActiveInstance().getPlugin("cloudbees-folder") != null;
     }
     
     private void modifyOwnership(Item item, OwnershipDescription ownership) {

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderItemListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 Oleg Nenashev.
+ * Copyright (c) 2016-2017 Oleg Nenashev.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 package org.jenkinsci.plugins.ownership.model.folders;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.cloudbees.hudson.plugins.folder.Folder;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.extensions.ItemOwnershipPolicy;
@@ -36,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Locates changes in {@link Folder}s and assigns ownership accordingly.
+ * Locates changes in {@link AbstractFolder}s and assigns ownership accordingly.
  * @author Oleg Nenashev
  */
 @Extension(optional = true)

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Oleg Nenashev.
+ * Copyright (c) 2015-2017 Oleg Nenashev.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 package org.jenkinsci.plugins.ownership.model.folders;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.cloudbees.hudson.plugins.folder.Folder;
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.ItemOwnershipAction;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
@@ -45,7 +44,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 /**
- * Allows managing actions for {@link Folder}s.
+ * Allows managing actions for {@link AbstractFolder}s.
  * @author Oleg Nenashev
  * @since 0.9
  */
@@ -55,7 +54,7 @@ public class FolderOwnershipAction extends ItemOwnershipAction<AbstractFolder<?>
     private static final OwnershipLayoutFormatter<AbstractFolder<?>> DEFAULT_FOLDER_FORMATTER 
             = new OwnershipLayoutFormatter.DefaultJobFormatter<AbstractFolder<?>>();
     
-    public FolderOwnershipAction(@Nonnull Folder folder) {
+    public FolderOwnershipAction(@Nonnull AbstractFolder<?> folder) {
         super(folder);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipActionFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Oleg Nenashev.
+ * Copyright (c) 2015-2017 Oleg Nenashev.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,12 @@
  */
 package org.jenkinsci.plugins.ownership.model.folders;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
-import com.cloudbees.hudson.plugins.folder.TransientFolderActionFactory;
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.Extension;
 import hudson.model.Action;
 import java.util.Collection;
 import java.util.Collections;
+import jenkins.model.TransientActionFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -38,10 +38,15 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 @Extension(optional = true)
 @Restricted(NoExternalUse.class)
-public class FolderOwnershipActionFactory extends TransientFolderActionFactory {
+public class FolderOwnershipActionFactory extends TransientActionFactory<AbstractFolder> {
 
     @Override
-    public Collection<? extends Action> createFor(Folder target) {
+    public Collection<? extends Action> createFor(AbstractFolder target) {
         return Collections.singleton(new FolderOwnershipAction(target));
+    }
+
+    @Override
+    public Class<AbstractFolder> type() {
+        return AbstractFolder.class;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Oleg Nenashev.
+ * Copyright (c) 2015-2017 Oleg Nenashev.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,14 +24,9 @@
 package org.jenkinsci.plugins.ownership.model.folders;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
-import com.cloudbees.hudson.plugins.folder.Folder;
-import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPluginConfiguration;
-import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
-import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserCollectionFilter;
 import com.synopsys.arc.jenkins.plugins.ownership.util.userFilters.AccessRightsFilter;
@@ -135,7 +130,7 @@ public class FolderOwnershipHelper extends AbstractOwnershipHelper<AbstractFolde
     @Override
     public Collection<User> getPossibleOwners(AbstractFolder<?> item) {
         if (OwnershipPlugin.getInstance().isRequiresConfigureRights()) {
-            IUserFilter filter = new AccessRightsFilter(item, Folder.CONFIGURE);
+            IUserFilter filter = new AccessRightsFilter(item, AbstractFolder.CONFIGURE);
             return UserCollectionFilter.filterUsers(User.getAll(), true, filter);
         } else {
             return User.getAll();

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipProperty.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Oleg Nenashev.
+ * Copyright (c) 2015-2017 Oleg Nenashev.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,6 @@ package org.jenkinsci.plugins.ownership.model.folders;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
-import com.cloudbees.hudson.plugins.folder.Folder;
-import com.cloudbees.hudson.plugins.folder.FolderProperty;
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.IOwnershipItem;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
@@ -39,7 +37,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
- * Ownership property for {@link Folder}s.
+ * Ownership property for {@link AbstractFolder}s.
  * @author Oleg Nenashev
  * @since 0.9
  */


### PR DESCRIPTION
This change fixes handling of `ComputedFolder`s in the plugin classes, so Job types like Multi-branch Pipeline will also offer ownership management after the change. Tests are underway.

- [x] - [JENKINS-38353](https://issues.jenkins-ci.org/browse/JENKINS-38353) - All code should use `AbstractFolder` instead of `Folder`
- [x] - [JENKINS-38513](https://issues.jenkins-ci.org/browse/JENKINS-38513) - FolderItemListener should not fail when Folders plugin is not installed

@reviewbybees