### PR TITLE
[JENKINS-49744] - Generalize permission checks via Ownership Helpers to support folders

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -23,16 +23,14 @@
  */
 package com.synopsys.arc.jenkins.plugins.ownership;
 
-import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty;
+import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.IdStrategyComparator;
 import com.synopsys.arc.jenkins.plugins.ownership.util.OwnershipDescriptionHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.nodes.OwnerNodeProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
-import hudson.model.Computer;
 import hudson.model.Descriptor;
-import hudson.model.Job;
-import hudson.model.Node;
+import hudson.model.ModelObject;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
@@ -44,6 +42,8 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,6 +51,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -62,6 +63,9 @@ import org.kohsuke.stapler.StaplerRequest;
  * @since 0.0.3
  */
 public class OwnershipDescription implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(OwnershipDescription.class.getName());
+
     /**
      * Disabled description, which means that ownership is disabled
      */
@@ -392,29 +396,22 @@ public class OwnershipDescription implements Serializable {
         StaplerRequest request = Stapler.getCurrentRequest();
         if (request != null) {
             AccessControlled context = request.findAncestorObject(AccessControlled.class);
-            if (context instanceof Job) {
-                Job<?, ?> job = (Job)context;
-                JobOwnerJobProperty existing = job.getProperty(JobOwnerJobProperty.class);
-                if (existing == null || !Objects.equals(existing.getOwnership(), this)) {
-                    throwIfMissingPermission(job, OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP);
-                }
-                return;
-            } else if (context instanceof Computer) {
-                Node node = ((Computer)context).getNode();
-                if (node != null) {
-                    OwnerNodeProperty existing = node.getNodeProperties().get(OwnerNodeProperty.class);
-                    if (existing == null || !Objects.equals(existing.getOwnership(), this)) {
-                        throwIfMissingPermission(node, OwnershipPlugin.MANAGE_SLAVES_OWNERSHIP);
+            if (context != null) {
+                final AbstractOwnershipHelper<AccessControlled> helper = OwnershipHelperLocator.locate(context);
+                if (helper != null) {
+                    final OwnershipDescription d = helper.getOwnershipDescription(context);
+                    if (!helper.hasLocallyDefinedOwnership(context) || !Objects.equals(d, this)) {
+                        throwIfMissingPermission(context, helper.getRequiredPermission());
                     }
                     return;
+                } else {
+                    LOGGER.log(Level.WARNING, "Cannot locate OwnershipHelperClass for object {0}. " +
+                            "Jenkins.ADMINISTER permissions will be required to change ownership", context);
                 }
-            } else if (context instanceof Node) {
-                Node node = ((Node)context);
-                OwnerNodeProperty existing = node.getNodeProperties().get(OwnerNodeProperty.class);
-                if (existing == null || !Objects.equals(existing.getOwnership(), this)) {
-                    throwIfMissingPermission(node, OwnershipPlugin.MANAGE_SLAVES_OWNERSHIP);
-                }
-                return;
+            } else {
+                //TODO: maybe it should rejected, because there is no use-cases for it so far AFAIK
+                LOGGER.log(Level.WARNING, "Ownership Description is used outside the object context. " +
+                        "Jenkins.ADMINISTER permissions will be required to change ownership");
             }
         }
         // We don't know what object this OwnershipDescription belongs to, so we require Overall/Administer permissions.

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipDescription.java
@@ -422,11 +422,22 @@ public class OwnershipDescription implements Serializable {
         throwIfMissingPermission(Jenkins.getActiveInstance(), Jenkins.ADMINISTER);
     }
 
-    private void throwIfMissingPermission(AccessControlled context, Permission permission) throws ObjectStreamException {
+    private void throwIfMissingPermission(@Nonnull AccessControlled context, Permission permission) throws ObjectStreamException {
         try {
             context.checkPermission(permission);
         } catch (AccessDeniedException e) {
-            throw new InvalidObjectException(e.getMessage());
+            final String name;
+            if (context instanceof ModelObject) {
+                name = ((ModelObject)context).getDisplayName();
+            } else {
+                name = context.toString();
+            }
+
+            InvalidObjectException ex = new InvalidObjectException(
+                    String.format("Cannot modify permissions of %s of type %s: %s", name,
+                            context.getClass(), e.getMessage()));
+            ex.addSuppressed(e);
+            throw ex;
         }
     }
 

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 import org.jenkinsci.plugins.ownership.model.jobs.JobOwnershipDescriptionSource;
@@ -92,6 +94,16 @@ public class JobOwnerHelper extends AbstractOwnershipHelper<Job<?,?>> {
     public @Nonnull OwnershipDescription getOwnershipDescription(@Nonnull Job<?, ?> job) {
         // TODO: Maybe makes sense to unwrap the method to get a better performance (esp. for Security)
         return getOwnershipInfo(job).getDescription();
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
+    }
+
+    @Override
+    public boolean hasLocallyDefinedOwnership(@Nonnull Job<?, ?> job) {
+        return getOwnerProperty(job) != null;
     }
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerHelper.java
@@ -47,6 +47,8 @@ import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 import org.jenkinsci.plugins.ownership.model.jobs.JobOwnershipDescriptionSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Helper for Jobs Ownership.
@@ -198,6 +200,7 @@ public class JobOwnerHelper extends AbstractOwnershipHelper<Job<?,?>> {
     }
     
     @Extension
+    @Restricted(NoExternalUse.class)
     public static class LocatorImpl extends OwnershipHelperLocator<Job<?,?>> {
         
         @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
@@ -26,6 +26,7 @@ package com.synopsys.arc.jenkins.plugins.ownership.nodes;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
+import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.User;
@@ -36,7 +37,10 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import hudson.security.Permission;
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Provides ownership helper for {@link Computer}.
@@ -115,5 +119,18 @@ public class ComputerOwnerHelper extends AbstractOwnershipHelper<Computer> {
     public String getItemURL(Computer item) {
         //TODO: Absolute URL
         return item.getUrl();
+    }
+
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class LocatorImpl extends OwnershipHelperLocator<Computer> {
+
+        @Override
+        public AbstractOwnershipHelper<Computer> findHelper(Object item) {
+            if (item instanceof Computer) {
+                return INSTANCE;
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/ComputerOwnerHelper.java
@@ -24,6 +24,7 @@
 package com.synopsys.arc.jenkins.plugins.ownership.nodes;
 
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -33,6 +34,8 @@ import java.util.Collection;
 import java.util.Collections;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 
 /**
@@ -81,6 +84,21 @@ public class ComputerOwnerHelper extends AbstractOwnershipHelper<Computer> {
         }
         
         NodeOwnerHelper.setOwnership(node, descr);
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return OwnershipPlugin.MANAGE_SLAVES_OWNERSHIP;
+    }
+
+    @Override
+    public boolean hasLocallyDefinedOwnership(@Nonnull Computer computer) {
+        Node node = computer.getNode();
+        if (node == null) {
+            // Node is not defined => permission is detached
+            return false;
+        }
+        return NodeOwnerHelper.Instance.hasLocallyDefinedOwnership(node);
     }
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
@@ -37,6 +37,8 @@ import java.io.IOException;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 import org.jenkinsci.plugins.ownership.model.nodes.NodeOwnershipDescriptionSource;
 
@@ -83,7 +85,17 @@ public class NodeOwnerHelper extends AbstractOwnershipHelper<Node> {
         return prop != null ? new OwnershipInfo(OwnershipDescription.DISABLED_DESCR, 
                 new NodeOwnershipDescriptionSource(item)) : OwnershipInfo.DISABLED_INFO;
     }
-    
+
+    @Override
+    public Permission getRequiredPermission() {
+        return OwnershipPlugin.MANAGE_SLAVES_OWNERSHIP;
+    }
+
+    @Override
+    public boolean hasLocallyDefinedOwnership(@Nonnull Node node) {
+        return getOwnerProperty(node) != null;
+    }
+
     @Override
     public Collection<User> getPossibleOwners(Node item) {
         if (OwnershipPlugin.getInstance().isRequiresConfigureRights()) {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerHelper.java
@@ -29,7 +29,9 @@ import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserCollectionFilter;
 import com.synopsys.arc.jenkins.plugins.ownership.util.userFilters.AccessRightsFilter;
 import com.synopsys.arc.jenkins.plugins.ownership.util.userFilters.IUserFilter;
+import hudson.Extension;
 import hudson.model.Computer;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.User;
 
@@ -39,8 +41,11 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import hudson.security.Permission;
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 import org.jenkinsci.plugins.ownership.model.nodes.NodeOwnershipDescriptionSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Provides helper for Node owner.
@@ -137,5 +142,18 @@ public class NodeOwnerHelper extends AbstractOwnershipHelper<Node> {
     public String getItemURL(Node item) {
         Computer c = item.toComputer();
         return c != null ? ComputerOwnerHelper.INSTANCE.getItemURL(c) : null;
+    }
+
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class LocatorImpl extends OwnershipHelperLocator<Node> {
+
+        @Override
+        public AbstractOwnershipHelper<Node> findHelper(Object item) {
+            if (item instanceof Node) {
+                return Instance;
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
@@ -27,6 +27,8 @@ import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
 import com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserCollectionFilter;
+import hudson.Extension;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.User;
 import hudson.security.Permission;
@@ -34,8 +36,12 @@ import hudson.slaves.NodeProperty;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 import org.jenkinsci.plugins.ownership.model.nodes.NodeOwnershipDescriptionSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Provides helper for Node owner
@@ -121,5 +127,18 @@ public class NodeOwnerPropertyHelper extends AbstractOwnershipHelper<NodePropert
     public String getItemURL(NodeProperty item) {
         Node node = getNode(item);
         return node != null ? NodeOwnerHelper.Instance.getItemURL(node) : null;
-    }     
+    }
+
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class LocatorImpl extends OwnershipHelperLocator<NodeProperty> {
+
+        @Override
+        public AbstractOwnershipHelper<NodeProperty> findHelper(Object item) {
+            if (item instanceof NodeProperty) {
+                return Instance;
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnerPropertyHelper.java
@@ -29,6 +29,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserCollectionFilter;
 import hudson.model.Node;
 import hudson.model.User;
+import hudson.security.Permission;
 import hudson.slaves.NodeProperty;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
@@ -92,6 +93,17 @@ public class NodeOwnerPropertyHelper extends AbstractOwnershipHelper<NodePropert
             return prop.getNode();
         }
         return null;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return OwnershipPlugin.MANAGE_SLAVES_OWNERSHIP;
+    }
+
+    @Override
+    public boolean hasLocallyDefinedOwnership(@Nonnull NodeProperty item) {
+        // Self-defined
+        return true;
     }
 
     @Override

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/util/AbstractOwnershipHelper.java
@@ -31,6 +31,9 @@ import java.util.Collection;
 import java.util.Collections;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 
 /**
@@ -105,4 +108,24 @@ public abstract class AbstractOwnershipHelper<TObjectType>
      */
     @Nonnull
     public abstract OwnershipInfo getOwnershipInfo(@Nonnull TObjectType item);
+
+    /**
+     * Gets permission required to manage ownership for the item.
+     * {@link Jenkins#ADMINISTER} by default if not overridden.
+     * @return Permission which is needed to change ownership.
+     * @since TODO
+     */
+    @Nonnull
+    public Permission getRequiredPermission() {
+        return Jenkins.ADMINISTER;
+    }
+
+    /**
+     * Check if the objeck has locally defined ownership info.
+     * @param item Item
+     * @return {@code true} if the object has ownership defined locally.
+     *         {@code false} will be returned otherwise, even if ownership is inherited.
+     * @since TODO
+     */
+    public boolean hasLocallyDefinedOwnership(@Nonnull TObjectType item) { return false; }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
@@ -43,6 +43,8 @@ import javax.annotation.Nonnull;
 import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Integration with Folders plugin.
@@ -166,6 +168,7 @@ public class FolderOwnershipHelper extends AbstractOwnershipHelper<AbstractFolde
     }
     
     @Extension(optional = true)
+    @Restricted(NoExternalUse.class)
     public static class LocatorImpl extends OwnershipHelperLocator<AbstractFolder<?>> {
         
         @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipHelper.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 
@@ -86,6 +88,17 @@ public class FolderOwnershipHelper extends AbstractOwnershipHelper<AbstractFolde
     public OwnershipDescription getOwnershipDescription(AbstractFolder<?> item) {
         // TODO: Maybe makes sense to unwrap the method to get a better performance (esp. for Security)
         return getOwnershipInfo(item).getDescription();
+    }
+
+    @Nonnull
+    @Override
+    public Permission getRequiredPermission() {
+        return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
+    }
+
+    @Override
+    public boolean hasLocallyDefinedOwnership(@Nonnull AbstractFolder<?> folder) {
+        return getOwnerProperty(folder) != null;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -30,6 +30,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.nodes.OwnerNodeProperty;
 import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
 import com.synopsys.arc.jenkins.plugins.ownership.util.UserStringFormatter;
+import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Node;
@@ -39,7 +40,10 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import hudson.security.Permission;
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Helper for {@link Run} ownership management.
@@ -48,10 +52,10 @@ import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
  */
 public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
 
-    private static final RunOwnershipHelper instance = new RunOwnershipHelper();
+    private static final RunOwnershipHelper INSTANCE = new RunOwnershipHelper();
 
     public static RunOwnershipHelper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     @Override
@@ -150,5 +154,18 @@ public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
     public boolean isDisplayOwnershipSummaryBox(Run item) {
         return super.isDisplayOwnershipSummaryBox(item) &&
                !OwnershipPlugin.getInstance().getConfiguration().getDisplayOptions().isHideRunOwnership();
+    }
+
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class LocatorImpl extends OwnershipHelperLocator<Run> {
+
+        @Override
+        public AbstractOwnershipHelper<Run> findHelper(Object item) {
+            if (item instanceof Run) {
+                return INSTANCE;
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/model/runs/RunOwnershipHelper.java
@@ -37,6 +37,8 @@ import hudson.model.Run;
 import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.security.Permission;
 import org.jenkinsci.plugins.ownership.model.OwnershipInfo;
 
 /**
@@ -76,7 +78,13 @@ public class RunOwnershipHelper extends AbstractOwnershipHelper<Run> {
     public OwnershipInfo getOwnershipInfo(Run item) {
         return JobOwnerHelper.Instance.getOwnershipInfo(item.getParent());
     }
-    
+
+    @Override
+    public Permission getRequiredPermission() {
+        // Runs do not have separate permission management logic now, so we rely on Items
+        return OwnershipPlugin.MANAGE_ITEMS_OWNERSHIP;
+    }
+
     /**
      * Environment setup according to wrapper configurations.
      * @param build Input build

--- a/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobPropertyTest.java
+++ b/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobPropertyTest.java
@@ -40,6 +40,7 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -70,6 +71,7 @@ public class JobOwnerJobPropertyTest {
     }
 
     @Test
+    @Issue("SECURITY-498")
     public void changeOwnerViaPost() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getProperty(JobOwnerJobProperty.class).setOwnershipDescription(new OwnershipDescription(true, "admin", null));
@@ -100,6 +102,7 @@ public class JobOwnerJobPropertyTest {
     }
 
     @Test
+    @Issue("SECURITY-498")
     public void changeOwnerViaCLI() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getProperty(JobOwnerJobProperty.class).setOwnershipDescription(new OwnershipDescription(true, "admin", null));

--- a/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/OwnerNodePropertyTest.java
+++ b/src/test/java/com/synopsys/arc/jenkins/plugins/ownership/nodes/OwnerNodePropertyTest.java
@@ -38,6 +38,7 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
@@ -67,6 +68,7 @@ public class OwnerNodePropertyTest {
     }
 
     @Test
+    @Issue("SECURITY-498")
     public void changeOwnerViaPost() throws Exception {
         String nodeName; // Computer#updateByXml replaces the existing node with a new instance, so we always need to look up the current instance.
         String nodeUrl;
@@ -103,6 +105,7 @@ public class OwnerNodePropertyTest {
     }
 
     @Test
+    @Issue("SECURITY-498")
     public void changeOwnerViaCLI() throws Exception {
         String nodeName;
         {

--- a/src/test/java/org/jenkinsci/plugins/ownership/folders/FolderOwnershipPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ownership/folders/FolderOwnershipPropertyTest.java
@@ -1,0 +1,174 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc., Oleg Nenashev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.ownership.folders;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.synopsys.arc.jenkins.plugins.ownership.OwnershipDescription;
+import com.synopsys.arc.jenkins.plugins.ownership.util.AbstractOwnershipHelper;
+import hudson.cli.CLICommandInvoker;
+import hudson.cli.UpdateJobCommand;
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.ownership.model.OwnershipHelperLocator;
+import org.jenkinsci.plugins.ownership.model.folders.FolderOwnershipHelper;
+import org.jenkinsci.plugins.ownership.model.folders.FolderOwnershipProperty;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+// TODO: DRY, merge with JobOwnerJobHelper once helper#setOwnership() is a non-static method
+@For(FolderOwnershipProperty.class)
+public class FolderOwnershipPropertyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private Folder p;
+    private AbstractOwnershipHelper<Folder> ownershipHelper;
+
+    @Before
+    public void setupSecurity() {
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        MockAuthorizationStrategy mas = new MockAuthorizationStrategy();
+        mas.grant(Jenkins.ADMINISTER) // Implies MANAGE_ITEMS_OWNERSHIP.
+                .everywhere()
+                .to("admin");
+        mas.grant(Item.CONFIGURE, Item.READ, Jenkins.READ)
+                .everywhere()
+                .to("non-admin");
+        r.jenkins.setAuthorizationStrategy(mas);
+    }
+
+    @Before
+    public void initFolder() throws Exception {
+        // Unique project name
+        p = r.createProject(Folder.class, "test" + r.jenkins.getItems().size());
+        ownershipHelper = OwnershipHelperLocator.locate(p);
+        if (ownershipHelper == null) {
+            throw new AssertionError("Cannot locate ownership helper for " + p + " of type " + p.getClass());
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-49744")
+    public void changeOwnerViaPost() throws Exception {
+        FolderOwnershipHelper.setOwnership(p,
+                new OwnershipDescription(true, "admin", null));
+
+        WebClient wc = r.createWebClient();
+        wc.login("non-admin", "non-admin");
+        WebRequest req = new WebRequest(wc.createCrumbedUrl(String.format("%sconfig.xml", p.getUrl())), HttpMethod.POST);
+        req.setAdditionalHeader("Content-Type", "application/xml");
+        req.setRequestBody(getItemXml("admin"));
+        wc.getPage(req);
+        assertThat("Users should be able to configure Folder when ownership is unchanged",
+                ownershipHelper.getOwner(p), is(equalTo("admin")));
+
+        try {
+            wc.login("non-admin", "non-admin");
+            req.setRequestBody(getItemXml("non-admin"));
+            wc.getPage(req);
+        } catch (FailingHttpStatusCodeException e) {
+            // fine
+        }
+        assertThat(ownershipHelper.getOwner(p), is(equalTo("admin")));
+
+        wc.login("admin", "admin");
+        req.setRequestBody(getItemXml("non-admin"));
+        wc.getPage(req);
+        assertThat("Users with Manage Ownership/Jobs permissions should be able to change ownership",
+                ownershipHelper.getOwner(p), is(equalTo("non-admin")));
+    }
+
+    @Test
+    @Issue("JENKINS-49744")
+    public void changeOwnerViaCLI() throws Exception {
+        FolderOwnershipHelper.setOwnership(p,
+                new OwnershipDescription(true, "admin", null));
+
+        CLICommandInvoker command = new CLICommandInvoker(r, new UpdateJobCommand())
+                .asUser("non-admin")
+                .withArgs(p.getFullName())
+                .withStdin(getItemXmlAsStream("admin"));
+        assertThat(ownershipHelper.getOwner(p), is(equalTo("admin")));
+
+        command.asUser("admin")
+                .withArgs(p.getFullName())
+                .withStdin(getItemXmlAsStream("non-admin"));
+        assertThat("Users with Overall/Administer permissions should be able to configure jobs via CLI", 
+                command.invoke(), succeededSilently());
+        assertThat(ownershipHelper.getOwner(p), is(equalTo("non-admin")));
+    }
+
+    private String getItemXml(String ownerSid) {
+        return String.format(FOLDER_XML_TEMPLATE, ownerSid);
+    }
+
+    private InputStream getItemXmlAsStream(String ownerSid) {
+        return new ByteArrayInputStream(getItemXml(ownerSid).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final String FOLDER_XML_TEMPLATE =
+            "<?xml version='1.0' encoding='UTF-8'?>" +
+            "<com.cloudbees.hudson.plugins.folder.Folder plugin=\"cloudbees-folder@6.1.0\">" +
+            "  <properties>" +
+            "    <org.jenkinsci.plugins.ownership.model.folders.FolderOwnershipProperty plugin=\"ownership@0.10.1\">" +
+            "        <ownership>" +
+            "           <ownershipEnabled>true</ownershipEnabled>" +
+            "           <primaryOwnerId>%s</primaryOwnerId>" +
+            "           <coownersIds class=\"sorted-set\"/>" +
+            "       </ownership>" +
+            "   </org.jenkinsci.plugins.ownership.model.folders.FolderOwnershipProperty>" +
+            "  </properties>" +
+            "  <views>\n" +
+            "    <hudson.model.AllView>\n" +
+            "      <owner class=\"com.cloudbees.hudson.plugins.folder.Folder\" reference=\"../../..\"/>\n" +
+            "      <name>All</name>\n" +
+            "      <filterExecutors>false</filterExecutors>\n" +
+            "      <filterQueue>false</filterQueue>\n" +
+            "      <properties class=\"hudson.model.View$PropertyList\"/>\n" +
+            "    </hudson.model.AllView>\n" +
+            "  </views>\n" +
+            "  <viewsTabBar class=\"hudson.views.DefaultViewsTabBar\"/>" +
+            "</com.cloudbees.hudson.plugins.folder.Folder>";
+
+}


### PR DESCRIPTION
It is a follow-up to the regression introduced by the SECURITY-498 fix in . It caused regressions in Folder handling: https://issues.jenkins-ci.org/browse/JENKINS-49744 

- [x] - Extend OwnershipHelper APIs to support permission checks
- [x] - Improve diagnosability of permission check errors
- [x] - Introduce `OwnershipHelperLocator`s for `Computer` and `Node` classes
- [x] - Add direct unit tests for Folders

@reviewbybees @dwnusbaum 

