### PR TITLE
Update SCM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
I was having some trouble running the PCT for this plugin, and I think part of the issue was that the with URLs as they were configured before the PCT was executing ` git clone ssh://github.com/jenkinsci/ownership-plugin.git` which I don't think can work. I'm not 100% sure how these URLs work so I might be mistaken. My changes would make them match what is currently used in the [empty-plugin maven archetype](https://github.com/jenkinsci/archetypes/blob/master/empty-plugin/src/main/resources/archetype-resources/pom.xml#L29-L30).