### PR TITLE
Ownership 1.0: Update dependencies and require Jenkins 2.60.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.5</version>
+        <version>3.18</version>
     </parent>
     
     <groupId>com.synopsys.jenkinsci</groupId>
@@ -23,11 +23,11 @@
     </licenses>	
 
     <properties>
-        <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <workflow.version>1.14</workflow.version>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <findbugs.effort>Max</findbugs.effort>
+        <!-- Uses restricted Security Inspector API -->
+        <useBeta>true</useBeta>
     </properties>
 
     <developers>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
             <artifactId>job-restrictions</artifactId>
-            <version>0.1</version>
+            <version>0.8</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.20</version>
+            <version>1.42</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -88,24 +88,24 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>security-inspector</artifactId>
-            <version>0.4</version>
+            <version>0.5-20181007.200044-1</version>
             <optional>true</optional>
         </dependency>
         <!--Plugins decoupled from the core. Would be great to make these deps optional.-->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.6</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>1.7</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.13</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -115,27 +115,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.53</version>
         </dependency>
         
         <!-- Test framework -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.15</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!--Implicitly required by folders-->

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/securityinspector/PermissionsForOwnerReportBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/securityinspector/PermissionsForOwnerReportBuilder.java
@@ -44,7 +44,6 @@ import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-import org.jenkinsci.plugins.securityinspector.Messages;
 import static org.jenkinsci.plugins.securityinspector.SecurityInspectorAction.getSessionId;
 import org.jenkinsci.plugins.securityinspector.UserContext;
 import org.jenkinsci.plugins.securityinspector.UserContextCache;

--- a/src/main/resources/org/jenkinsci/plugins/ownership/integrations/securityinspector/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/integrations/securityinspector/Messages.properties
@@ -1,0 +1,1 @@
+JobReport.RowColumnHeader=Items


### PR DESCRIPTION
Start the plugin cleanup towards Ownership Plugin 1.0
This version wi probably break binary compatibility and require some beta releases before GA.
Some fixes may be backported to the 0.x branch, but Core requirements won't be bumped there until major issues are resolved.

Downstream of https://github.com/jenkinsci/security-inspector-plugin/pull/7