### PR TITLE
[WIP] [JENKINS-46790] Expose a RecipientProvider for ownership

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.6</version>
+            <version>1.12.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>email-ext</artifactId>
-            <version>2.62</version>
+            <version>2.47</version>
             <optional>true</optional>
         </dependency>
         <!--Plugins decoupled from the core. Would be great to make these deps optional.-->
@@ -123,7 +123,11 @@
             <artifactId>workflow-cps</artifactId>
             <version>${workflow.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.6</version>
+        </dependency>
         <!-- Test framework -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
         <artifactId>plugin</artifactId>
         <version>3.5</version>
     </parent>
-    
+
     <groupId>com.synopsys.jenkinsci</groupId>
     <artifactId>ownership</artifactId>
     <version>0.12.2-SNAPSHOT</version>
@@ -13,14 +13,14 @@
     <packaging>hpi</packaging>
     <description>Provides explicit ownership of jobs and nodes</description>
     <url>https://wiki.jenkins.io/display/JENKINS/Ownership+Plugin</url>
-    
+
     <licenses>
         <license>
             <name>MIT License</name>
             <url>http://www.opensource.org/licenses/mit-license.php</url>
             <distribution>repo</distribution>
         </license>
-    </licenses>	
+    </licenses>
 
     <properties>
         <jenkins.version>1.651.3</jenkins.version>
@@ -34,7 +34,7 @@
       <developer>
         <id>oleg_nenashev</id>
         <name>Oleg Nenashev</name>
-        <email>o.v.nenashev@gmail.com</email>                 
+        <email>o.v.nenashev@gmail.com</email>
         <roles>
           <role>maintainer</role>
         </roles>
@@ -47,7 +47,7 @@
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
     </scm>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -91,6 +91,12 @@
             <version>0.4</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>email-ext</artifactId>
+            <version>2.62</version>
+            <optional>true</optional>
+        </dependency>
         <!--Plugins decoupled from the core. Would be great to make these deps optional.-->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -117,7 +123,7 @@
             <artifactId>workflow-cps</artifactId>
             <version>${workflow.version}</version>
         </dependency>
-        
+
         <!-- Test framework -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -145,8 +151,8 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-   
-    <repositories> 
+
+    <repositories>
       <repository>
         <id>repo.jenkins-ci.org</id>
         <url>https://repo.jenkins-ci.org/public/</url>

--- a/src/main/java/org/jenkinsci/plugins/ownership/recipients/OwnershipRecipientProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/recipients/OwnershipRecipientProvider.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Victor Martinez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ownership.recipients;
+
+import com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.plugins.emailext.EmailRecipientUtils;
+import hudson.plugins.emailext.ExtendedEmailPublisherContext;
+import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
+import hudson.plugins.emailext.plugins.RecipientProvider;
+import hudson.plugins.emailext.plugins.RecipientProviderDescriptor;
+import hudson.plugins.emailext.plugins.recipients.RecipientProviderUtilities;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import java.io.PrintStream;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Victor Martinez
+ */
+@Extension(optional = true)
+public class OwnershipRecipientProvider extends RecipientProvider {
+
+    @DataBoundConstructor
+    public OwnershipRecipientProvider() {
+
+    }
+
+    @Override
+    public void addRecipients(final ExtendedEmailPublisherContext context, EnvVars env, Set<InternetAddress> to, Set<InternetAddress> cc, Set<InternetAddress> bcc) {
+        final class Debug implements RecipientProviderUtilities.IDebug {
+            private final ExtendedEmailPublisherDescriptor descriptor
+                    = Jenkins.getActiveInstance().getDescriptorByType(ExtendedEmailPublisherDescriptor.class);
+
+            private final PrintStream logger = context.getListener().getLogger();
+
+            public void send(final String format, final Object... args) {
+                descriptor.debug(logger, format, args);
+            }
+        }
+        final Debug debug = new Debug();
+        // looking for Upstream build.
+        Run<?, ?> cur = context.getRun();
+        Cause.UpstreamCause upc = cur.getCause(Cause.UpstreamCause.class);
+        Job<?, ?> p = null;
+        while (upc != null) {
+            // UpstreamCause.getUpStreamProject() returns the full name, so use getItemByFullName
+            p = (Job<?, ?>) Jenkins.getActiveInstance().getItemByFullName(upc.getUpstreamProject());
+            if (p == null) {
+                context.getListener().getLogger().print("There is a break in the project linkage, could not retrieve upstream project information");
+                break;
+            }
+        }
+        try {
+            addJobOwner(p, to, cc, bcc, env, context, debug);
+        } catch (MessagingException e) {
+            Logger.getLogger(OwnershipRecipientProvider.class.getName()).log(Level.SEVERE, null, e);
+        }
+    }
+
+    private static void addJobOwner(Job<?,?> job, Set<InternetAddress> to,
+                                                  Set<InternetAddress> cc, Set<InternetAddress> bcc, EnvVars env, final ExtendedEmailPublisherContext context, RecipientProviderUtilities.IDebug debug) throws MessagingException {
+        final String owner = job.getProperty(JobOwnerJobProperty.class).getOwnership().getPrimaryOwnerEmail();
+        if (owner != null) {
+            EmailRecipientUtils.addAddressesFromRecipientList(to, cc, bcc, EmailRecipientUtils.getRecipientList(context, owner), env, context.getListener());
+        }
+    }
+
+    //return User.get(id, false, (Map)null);
+
+    @Extension
+    @Symbol("owners")
+    public static final class DescriptorImpl extends RecipientProviderDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Owners";
+        }
+
+    }
+}


### PR DESCRIPTION
See [JENKINS-46790](https://issues.jenkins-ci.org/browse/JENKINS-46790)

**NOTE**: This is just a quite basic implementation, copy/paste based with some minor tweaks, without any UTs. Just implemented with the purpose to expose the current implementation and get some early feedback whether it's a good approach and even without any manual yet!

## Highlights:
- Bump `token-macro` to be able to use email-ext
- Add `struct` dependency to support the `Symbol` annotation.
- Use the primary owner email

## Questions:
- `email-ext` UTs uses `PowerMock` while this plugin uses the `JenkinsRule` framework, what's the best approach to add some test coverage?
- I'd rather consider to use the primary owner and in the future to expose the `co-owners` recipient list. What do you think?

