### PR TITLE
Update Jenkins Core requirement to 2.138.3, use jenkinsci/bom as a source of dependency versions 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.18</version>
+        <version>3.49</version>
     </parent>
     
     <groupId>com.synopsys.jenkinsci</groupId>
     <artifactId>ownership</artifactId>
-    <version>0.13.1-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <name>Job and Node ownership plugin</name>
     <packaging>hpi</packaging>
     <description>Provides explicit ownership of jobs and nodes</description>
@@ -23,7 +23,7 @@
     </licenses>	
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.138.3</jenkins.version>
         <java.level>8</java.level>
         <findbugs.effort>Max</findbugs.effort>
         <!-- Uses restricted Security Inspector API -->
@@ -47,7 +47,19 @@
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
     </scm>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.138.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -58,7 +70,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.6</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -70,13 +81,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.42</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.1.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -91,11 +100,10 @@
             <version>0.5</version>
             <optional>true</optional>
         </dependency>
-        <!--Plugins decoupled from the core. Would be great to make these deps optional.-->
+        <!--TODO: Plugins decoupled from the core. Would be great to make these deps optional.-->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -105,43 +113,36 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.3-2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.53</version>
         </dependency>
         
         <!-- Test framework -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.15</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!--Implicitly required by folders-->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.5</version>
+        <version>3.18</version>
     </parent>
     
     <groupId>com.synopsys.jenkinsci</groupId>
@@ -23,11 +23,11 @@
     </licenses>	
 
     <properties>
-        <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <workflow.version>1.14</workflow.version>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <findbugs.effort>Max</findbugs.effort>
+        <!-- Uses restricted Security Inspector API -->
+        <useBeta>true</useBeta>
     </properties>
 
     <developers>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
             <artifactId>job-restrictions</artifactId>
-            <version>0.1</version>
+            <version>0.8</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.20</version>
+            <version>1.42</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -88,24 +88,24 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>security-inspector</artifactId>
-            <version>0.4</version>
+            <version>0.5-20181007.200044-1</version>
             <optional>true</optional>
         </dependency>
         <!--Plugins decoupled from the core. Would be great to make these deps optional.-->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.6</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>1.7</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.13</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -115,27 +115,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.53</version>
         </dependency>
         
         <!-- Test framework -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.15</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!--Implicitly required by folders-->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     
     <groupId>com.synopsys.jenkinsci</groupId>
     <artifactId>ownership</artifactId>
-    <version>0.12.2-SNAPSHOT</version>
+    <version>0.13.1-SNAPSHOT</version>
     <name>Job and Node ownership plugin</name>
     <packaging>hpi</packaging>
     <description>Provides explicit ownership of jobs and nodes</description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>security-inspector</artifactId>
-            <version>0.5-20181007.200044-1</version>
+            <version>0.5</version>
             <optional>true</optional>
         </dependency>
         <!--Plugins decoupled from the core. Would be great to make these deps optional.-->

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin.java
@@ -88,13 +88,19 @@ public class OwnershipPlugin extends Plugin {
     public static OwnershipPlugin Instance() {
         return getInstance();
     }
-    
+
+    /**
+     * Get the plugin instance.
+     * @return Plugin instance
+     * @throws IllegalStateException Jenkins instance or the plugin have not been initialized yet
+     */
+    @Nonnull
     public static OwnershipPlugin getInstance() {
-        Jenkins j = Jenkins.getInstance();
-        OwnershipPlugin plugin = j != null ? j.getPlugin(OwnershipPlugin.class) : null;
+        Jenkins j = Jenkins.get();
+        OwnershipPlugin plugin = j.getPlugin(OwnershipPlugin.class);
         if (plugin == null) { // Fail horribly
             // TODO: throw a graceful error
-            throw new IllegalStateException("Cannot get the plugin's instance. Jenkins or the plugin have not been initialized yet");
+            throw new IllegalStateException("Cannot get the plugin's instance. The plugin have not been initialized yet");
         }
         return plugin;
     }

--- a/src/main/java/org/jenkinsci/plugins/ownership/integrations/securityinspector/PermissionsForOwnerReportBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ownership/integrations/securityinspector/PermissionsForOwnerReportBuilder.java
@@ -44,7 +44,6 @@ import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-import org.jenkinsci.plugins.securityinspector.Messages;
 import static org.jenkinsci.plugins.securityinspector.SecurityInspectorAction.getSessionId;
 import org.jenkinsci.plugins.securityinspector.UserContext;
 import org.jenkinsci.plugins.securityinspector.UserContextCache;

--- a/src/main/resources/org/jenkinsci/plugins/ownership/integrations/securityinspector/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/integrations/securityinspector/Messages.properties
@@ -1,0 +1,1 @@
+JobReport.RowColumnHeader=Items


### PR DESCRIPTION
Spin-off of #75 which updates the plugin without pulling in the JCasC compatibility code and breaking changes.

Currently I cannot release the plugin, and this code update is required to do so

