### PR TITLE
JENKINS-62437: Remove table tags to avoid UI breakage

### DIFF
--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -34,70 +34,71 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:o="/lib/ownership">
     <!--Stuff-->
     <link rel="stylesheet" href="${rootURL}/plugin/ownership/css/ownership.css" type="text/css" />
     <j:set var="layoutFormatter" value="${it.layoutFormatter}"/>
     <j:set var="ownershipDescription" value="${helper.getOwnershipDescription(item)}"/>
-   
+
     <!-- Layout for ownership with available data -->
     <j:if test="${helper.isDisplayOwnershipSummaryBox(item) and ownershipDescription.ownershipEnabled}">
-      <div class="ownership-summary-box">   
+      <div class="ownership-summary-box">
         <input class="ownership-toggle-box" id="ownership-toogle-1" type="checkbox" />
-        <label for="ownership-toogle-1">${itemType} ${%Owners}</label>           
+        <label for="ownership-toogle-1">${itemType} ${%Owners}</label>
         <div>
-            <table>
-                <tr>
-                    <td>
+            <o:blockWrapper>
+                <o:rowWrapper>
+                    <o:cellWrapper>
                         <div class="ownership-section">${%Primary}</div>
-                    </td>
-                    <td>
+                    </o:cellWrapper>
+                    <o:cellWrapper>
                         <div class="ownership-user-info">
                             <j:out value="${layoutFormatter.formatOwner(item, helper.getOwner(item))}"/>
                         </div>
-                    </td>
-                </tr>
-            
-                <!-- Secondary owners (fka Co-owners) -->    
+                    </o:cellWrapper>
+                </o:rowWrapper>
+
+                <!-- Secondary owners (fka Co-owners) -->
                 <j:set var="coownersList" value="${helper.getOwnershipDescription(item).getCoownersIds()}"/>
                 <j:if test="${not coownersList.isEmpty()}">
-                    <tr>
-                        <td>        
+                    <o:rowWrapper>
+                        <o:cellWrapper>
                             <div class="ownership-section">${%Secondary}</div>
-                        </td>       
-                        <td>
+                        </o:cellWrapper>
+                        <o:cellWrapper>
                             <j:forEach var="coownerId" items="${coownersList}">
-                                <div class="ownership-user-info">                   
+                                <div class="ownership-user-info">
                                     <j:out value="${layoutFormatter.formatOwner(item, coownerId)}"/>
                                 </div>
-                            </j:forEach>  
-                        </td>
-                    </tr>
+                            </j:forEach>
+                        </o:cellWrapper>
+                    </o:rowWrapper>
                 </j:if>
-            </table>
-                 
-            <div class="ownership-contact-links"> 
-                <table>
-                    <tr>  
+            </o:blockWrapper>
+
+            <div class="ownership-contact-links">
+                <o:blockWrapper>
+                    <o:rowWrapper>
                         <!-- Contact Owners link -->
                         <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
-                        <j:if test="${ownersMailToLink != null}">   
-                            <td>    
+                        <j:if test="${ownersMailToLink != null}">
+                            <o:cellWrapper>
                                 <img src="${imagesURL}/24x24/user.png"/>
                                 <a href="${ownersMailToLink}">${%ownersMailToLink.text(itemType)}</a>
-                            </td>
+                            </o:cellWrapper>
                         </j:if>
 
                         <!-- Contact Admins link -->
                         <j:set var="adminsMailToLink" value="${layoutFormatter.formatContactAdminsLink(item,helper)}"/>
                         <j:if test="${adminsMailToLink != null}">
-                            <td>
+                            <o:cellWrapper>
                                 <img src="${imagesURL}/24x24/setting.png"/>
                                 <a href="${adminsMailToLink}">${%adminsMailToLink.text}</a>
-                            </td>
+                            </o:cellWrapper>
                         </j:if>
-                    </tr>
-                </table>
+                    </o:rowWrapper>
+                </o:blockWrapper>
             </div>
         </div>
       </div>

--- a/src/main/resources/lib/ownership/cellWrapper.jelly
+++ b/src/main/resources/lib/ownership/cellWrapper.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+  <st:documentation>
+    The wrapper will be a <code>div</code> tag on Jenkins pages with the <code>divBasedFormLayout</code> flag, and a <code>td</code> tag otherwise
+  </st:documentation>
+
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div>
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <td>
+        <d:invokeBody/>
+      </td>
+    </j:otherwise>
+  </j:choose>
+
+</j:jelly>

--- a/src/main/resources/lib/ownership/rowWrapper.jelly
+++ b/src/main/resources/lib/ownership/rowWrapper.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+  <st:documentation>
+    The wrapper will be a <code>div</code> tag on Jenkins pages with the <code>divBasedFormLayout</code> flag, and a <code>td</code> tag otherwise
+  </st:documentation>
+
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div class="tr">
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <tr>
+        <d:invokeBody/>
+      </tr>
+    </j:otherwise>
+  </j:choose>
+
+</j:jelly>


### PR DESCRIPTION
Add cell and row wrapper tags to support the new div layout.
This avoids other items (from other plugins) being cut of on the build overview.

Like #83, but with the fixed floatingBoxTemplate

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue <- Maybe I need some help with testing this.

@oleg-nenashev 
@timja 