### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/OwnershipPlugin/floatingBoxTemplate.jelly
@@ -83,7 +83,7 @@
                         <j:set var="ownersMailToLink" value="${layoutFormatter.formatContactOwnersLink(item,helper)}"/>
                         <j:if test="${ownersMailToLink != null}">   
                             <td>    
-                                <img src="${imagesURL}/24x24/user.png"/>
+                                <l:icon class="icon-user icon-md"/>
                                 <a href="${ownersMailToLink}">${%ownersMailToLink.text(itemType)}</a>
                             </td>
                         </j:if>
@@ -92,7 +92,7 @@
                         <j:set var="adminsMailToLink" value="${layoutFormatter.formatContactAdminsLink(item,helper)}"/>
                         <j:if test="${adminsMailToLink != null}">
                             <td>
-                                <img src="${imagesURL}/24x24/setting.png"/>
+                                <l:icon class="icon-setting icon-md"/>
                                 <a href="${adminsMailToLink}">${%adminsMailToLink.text}</a>
                             </td>
                         </j:if>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/configure-project-specifics.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/configure-project-specifics.jelly
@@ -28,7 +28,7 @@
         <st:include it="${it.describedItem}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/fingerprint.gif"/>
+                <l:icon class="icon-fingerprint icon-xlg"/>
                 ${%Manage item-specific access rights}
             </h1>
             <f:form method="post" name="config" action="projectSpecificSecuritySubmit">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/manage-owners.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/jobs/JobOwnerJobAction/manage-owners.jelly
@@ -29,7 +29,7 @@
         <l:main-panel>
             <f:form method="post" name="config" action="ownersSubmit">
                 <h1>
-                    <img src="${imagesURL}/48x48/user.gif"/>
+                    <l:icon class="icon-user icon-xlg"/>
                     ${%Manage Owners}
                 </h1>
                 <p style="color:red"><b>Warning! You may lose access rights to this page if you change ownership</b></p>

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/configure-project-specifics.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/configure-project-specifics.jelly
@@ -28,7 +28,7 @@
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/fingerprint.gif" alt="${%Configure node-specific access rights}" />
+                <l:icon class="icon-fingerprint icon-xlg" alt="${%Configure node-specific access rights}" />
                 ${%Configure node-specific access rights}
             </h1>
             <p style="color:red">

--- a/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/manage-owners.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkins/plugins/ownership/nodes/NodeOwnershipAction/manage-owners.jelly
@@ -29,7 +29,7 @@
         <l:main-panel>
             <f:form method="post" name="config" action="ownersSubmit">
                 <h1>
-                    <img src="${imagesURL}/48x48/user.gif" alt="${%Manage owners}" />
+                    <l:icon class="icon-user icon-xlg" alt="${%Manage owners}" />
                     ${%Manage Owners}
                 </h1>
                 <p style="color:red"><b>Warning! You may lose access rights to this page if you change ownership</b></p>

--- a/src/main/resources/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction/manage-owners.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ownership/model/folders/FolderOwnershipAction/manage-owners.jelly
@@ -29,7 +29,7 @@
         <l:main-panel>
             <f:form method="post" name="config" action="ownersSubmit">
                 <h1>
-                    <img src="${imagesURL}/48x48/user.gif"/>
+                    <l:icon class="icon-user icon-xlg"/>
                     ${%Manage Owners}
                 </h1>
                 <p style="color:red"><b>Warning! You may lose access rights to this page if you change ownership</b></p>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @oleg-nenashev 
Thanks in advance!